### PR TITLE
add act api formatters

### DIFF
--- a/src/formatters/__tests__/busPosition.test.ts
+++ b/src/formatters/__tests__/busPosition.test.ts
@@ -1,0 +1,240 @@
+import { createMockBusPositionRaw } from '../../services/__mocks__/actRealtimeResponses.js';
+import { createFeedMessage } from '../../services/__mocks__/gtfsRealtimeResponses.js';
+import { createBusPositionsFromActRealtime, createBusPositionsFromGtfsFeed } from '../busPosition.js';
+
+describe('createBusPositionsFromActRealtime', () => {
+    it('parses valid raw positions, converts speed mph->m/s, resolves tripId preference, tripId null fallback, and sorts by vehicleId', () => {
+        const p1 = createMockBusPositionRaw({
+            vid: 'A-2',
+            rt: '51A',
+            lat: '37.0000',
+            lon: '-122.0000',
+            spd: 12, // mph -> 5.36448 m/s
+            hdg: '180',
+            tatripid: 'TRIP-A',
+            tmstmp: '20240701 09:00',
+        });
+        const p2 = createMockBusPositionRaw({
+            vid: 'A-1',
+            rt: '51B',
+            lat: '36.5000',
+            lon: '-121.5000',
+            spd: undefined, // speed missing -> null
+            hdg: undefined, // heading missing -> null
+            tatripid: undefined, // prefer numeric tripid when string missing
+            tripid: 2468,
+            tmstmp: '20240701 09:05',
+        });
+        const p3 = createMockBusPositionRaw({
+            vid: 'A-3',
+            rt: '51C',
+            lat: '35.0000',
+            lon: '-120.9000',
+            spd: 0,
+            hdg: '0',
+            tatripid: undefined,
+            tripid: undefined,
+            tmstmp: '20240701 09:10',
+        });
+        const invalid = createMockBusPositionRaw({ vid: 'BAD', rt: '51A', lat: '', lon: '-122.1' }); // invalid lat -> filtered out
+
+        const result = createBusPositionsFromActRealtime([p1, p2, p3, invalid]);
+
+        expect(result).toHaveLength(3);
+        // Sorted by vehicleId: A-1, A-2, A-3
+        expect(result[0].vehicleId).toBe('A-1');
+        expect(result[0].routeId).toBe('51B');
+        expect(result[0].latitude).toBeCloseTo(36.5, 6);
+        expect(result[0].longitude).toBeCloseTo(-121.5, 6);
+        expect(result[0].heading).toBeNull();
+        expect(result[0].speed).toBeNull();
+        expect(result[0].tripId).toBe('2468');
+        expect(result[0].stopSequence).toBeNull();
+
+        expect(result[1].vehicleId).toBe('A-2');
+        expect(result[1].routeId).toBe('51A');
+        expect(result[1].heading).toBe(180);
+        expect(result[1].speed).toBeCloseTo(12 * 0.44704, 5);
+        expect(result[1].tripId).toBe('TRIP-A');
+        expect(result[1].stopSequence).toBeNull();
+
+        expect(result[2].vehicleId).toBe('A-3');
+        expect(result[2].tripId).toBeNull();
+        expect(result[2].speed).toBeCloseTo(0, 6);
+    });
+
+    it('returns empty when inputs are missing or invalid', () => {
+        const noRoute = createMockBusPositionRaw({ vid: 'X', rt: '   ' });
+        const noVehicle = createMockBusPositionRaw({ vid: '   ' });
+        const noCoords = createMockBusPositionRaw({ lat: '', lon: '' });
+        const result = createBusPositionsFromActRealtime([noRoute, noVehicle, noCoords]);
+        expect(result).toEqual([]);
+    });
+
+    it('returns empty for empty or undefined input arrays', () => {
+        expect(createBusPositionsFromActRealtime([])).toEqual([]);
+        expect(
+            createBusPositionsFromActRealtime(
+                undefined as unknown as Parameters<typeof createBusPositionsFromActRealtime>[0]
+            )
+        ).toEqual([]);
+    });
+
+    it('treats non-finite numeric strings as null (ACT speed)', () => {
+        const p = createMockBusPositionRaw({
+            vid: 'NF-1',
+            rt: '51N',
+            lat: '34.0000',
+            lon: '-121.0000',
+            spd: 'Infinity' as unknown as number, // string path -> Number('Infinity') is not finite
+            hdg: '90',
+            tmstmp: '20240701 10:00',
+        });
+
+        const [pos] = createBusPositionsFromActRealtime([p]);
+        expect(pos.vehicleId).toBe('NF-1');
+        expect(pos.speed).toBeNull();
+    });
+});
+
+describe('createBusPositionsFromGtfsFeed', () => {
+    it('parses valid entities, rounds stopSequence, picks vehicleId from descriptor or entity id, uses timestamps, and sorts by vehicleId', () => {
+        vi.useFakeTimers();
+        const now = new Date('2025-01-01T00:00:00.000Z');
+        vi.setSystemTime(now);
+        const nowSec = Math.floor(now.getTime() / 1000);
+
+        const feed = createFeedMessage([
+            // Uses vehicle.vehicle.id and vehicle.timestamp
+            {
+                id: 'entity-B',
+                vehicle: {
+                    trip: { routeId: '51A', tripId: 'TRIP-G1' },
+                    position: { latitude: 37.1, longitude: -122.2, bearing: 270, speed: 7.5 },
+                    currentStopSequence: 12.7, // rounds to 13
+                    vehicle: { id: 'B-2' },
+                    timestamp: nowSec - 45,
+                },
+            },
+            // Missing vehicle.vehicle.id -> falls back to entity.id; missing vehicle.timestamp -> uses header timestamp
+            {
+                id: 'A-1',
+                vehicle: {
+                    trip: { routeId: '51B', tripId: 'TRIP-G2' },
+                    position: { latitude: 37.2, longitude: -122.3 },
+                    currentStopSequence: 17,
+                },
+            },
+            // Invalid/missing cases filtered out
+            { id: 'no-vehicle' },
+            { id: 'no-route', vehicle: { position: { latitude: 1, longitude: 2 } } },
+            { id: 'bad-coords', vehicle: { trip: { routeId: '51A' }, position: { latitude: NaN, longitude: -10 } } },
+        ]);
+
+        const result = createBusPositionsFromGtfsFeed(feed);
+
+        // Expected two valid positions sorted by vehicleId: 'A-1' (fallback to entity id), 'B-2'
+        expect(result).toHaveLength(2);
+        expect(result[0].vehicleId).toBe('A-1');
+        expect(result[0].routeId).toBe('51B');
+        expect(result[0].latitude).toBeCloseTo(37.2, 6);
+        expect(result[0].longitude).toBeCloseTo(-122.3, 6);
+        expect(result[0].heading).toBeNull();
+        expect(result[0].speed).toBeNull();
+        expect(result[0].tripId).toBe('TRIP-G2');
+        expect(result[0].stopSequence).toBe(17);
+        expect(result[0].timestamp.toISOString()).toBe(now.toISOString()); // header timestamp
+
+        expect(result[1].vehicleId).toBe('B-2');
+        expect(result[1].routeId).toBe('51A');
+        expect(result[1].heading).toBe(270);
+        expect(result[1].speed).toBe(7.5);
+        expect(result[1].tripId).toBe('TRIP-G1');
+        expect(result[1].stopSequence).toBe(13);
+        expect(result[1].timestamp.toISOString()).toBe(new Date((nowSec - 45) * 1000).toISOString());
+
+        vi.useRealTimers();
+    });
+
+    it('returns empty array when no valid entities', () => {
+        const feed = createFeedMessage([{ id: 'only-alert', alert: { informedEntity: [{ routeId: '51A' }] } }]);
+        expect(createBusPositionsFromGtfsFeed(feed)).toEqual([]);
+    });
+
+    it('returns empty array when entity is empty or missing', () => {
+        const emptyFeed = createFeedMessage([]);
+        expect(createBusPositionsFromGtfsFeed(emptyFeed)).toEqual([]);
+
+        const missingEntity = {} as unknown as Parameters<typeof createBusPositionsFromGtfsFeed>[0];
+        expect(createBusPositionsFromGtfsFeed(missingEntity)).toEqual([]);
+    });
+
+    it('covers fallback branches: timestamp fallback to now, vehicleId empty path, null tripId and stopSequence, and non-finite numeric parsing', () => {
+        vi.useFakeTimers();
+        const now = new Date('2025-01-03T00:00:00.000Z');
+        vi.setSystemTime(now);
+
+        const feed = createFeedMessage([
+            // Valid entity but without tripId/stopSequence, Infinity speed (non-finite number), and no vehicle.timestamp
+            {
+                id: 'D-1',
+                vehicle: {
+                    trip: { routeId: '51D' },
+                    position: {
+                        latitude: 40.1 as unknown as number,
+                        longitude: -120.1 as unknown as number,
+                        speed: Number.POSITIVE_INFINITY as unknown as number,
+                    },
+                    vehicle: { id: 'D-1' },
+                },
+            },
+        ]);
+
+        // Break header timestamp so resolveTimestamp falls back to Date.now()
+        feed.header!.timestamp = undefined as unknown as number;
+
+        const result = createBusPositionsFromGtfsFeed(feed);
+
+        expect(result).toHaveLength(1);
+        const d1 = result[0];
+        expect(d1.vehicleId).toBe('D-1');
+        expect(d1.tripId).toBeNull(); // trip.tripId missing
+        expect(d1.stopSequence).toBeNull(); // currentStopSequence missing
+        expect(d1.speed).toBeNull(); // Infinity -> non-finite -> null
+        expect(d1.timestamp.toISOString()).toBe(now.toISOString()); // fallback to now
+
+        vi.useRealTimers();
+    });
+
+    it('parses numeric strings (with whitespace) via parseFiniteNumber for GTFS fields', () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+
+        const feed = createFeedMessage([
+            {
+                id: 'S-1',
+                vehicle: {
+                    trip: { routeId: '51S', tripId: 'TRIP-S' },
+                    // cast to exercise string branch in parseFiniteNumber
+                    position: {
+                        latitude: ' 37.300 ' as unknown as number,
+                        longitude: ' -122.400 ' as unknown as number,
+                        bearing: ' 123 ' as unknown as number,
+                        speed: ' 15.2 ' as unknown as number,
+                    },
+                    currentStopSequence: ' 4.4 ' as unknown as number, // rounds to 4
+                    vehicle: { id: 'S-1' },
+                    timestamp: nowSec - 30,
+                },
+            },
+        ]);
+
+        const [pos] = createBusPositionsFromGtfsFeed(feed);
+        expect(pos.vehicleId).toBe('S-1');
+        expect(pos.routeId).toBe('51S');
+        expect(pos.latitude).toBeCloseTo(37.3, 6);
+        expect(pos.longitude).toBeCloseTo(-122.4, 6);
+        expect(pos.heading).toBe(123);
+        expect(pos.speed).toBeCloseTo(15.2, 6);
+        expect(pos.stopSequence).toBe(4);
+    });
+});

--- a/src/formatters/__tests__/busStop.test.ts
+++ b/src/formatters/__tests__/busStop.test.ts
@@ -1,0 +1,39 @@
+import { createMockBusStopProfileRaw } from '../../services/__mocks__/actRealtimeResponses.js';
+import type { BusStopProfileRaw } from '../../services/actRealtime.js';
+import { createBusStopProfile } from '../busStop.js';
+
+describe('createBusStopProfile', () => {
+    it('creates a structured BusStopProfile from raw data', () => {
+        const raw: BusStopProfileRaw = createMockBusStopProfileRaw({
+            geoid: 'GTFS_STOP_123',
+            stpid: '50373',
+            stpnm: 'Main St & 1st Ave',
+            lat: 37.811845,
+            lon: -122.267098,
+        });
+
+        const profile = createBusStopProfile(raw);
+
+        expect(profile).toEqual({
+            id: 'GTFS_STOP_123',
+            code: '50373',
+            name: 'Main St & 1st Ave',
+            latitude: 37.811845,
+            longitude: -122.267098,
+        });
+    });
+
+    it('throws when geoid is missing', () => {
+        const raw = createMockBusStopProfileRaw();
+        delete (raw as unknown as Record<string, unknown>).geoid;
+        const bad = raw as unknown as BusStopProfileRaw;
+        expect(() => createBusStopProfile(bad)).toThrowError('Cannot create BusStopProfile without geoid');
+    });
+
+    it('throws when stpid is missing', () => {
+        const raw = createMockBusStopProfileRaw();
+        delete (raw as unknown as Record<string, unknown>).stpid;
+        const bad = raw as unknown as BusStopProfileRaw;
+        expect(() => createBusStopProfile(bad)).toThrowError('Cannot create BusStopProfile without stpid');
+    });
+});

--- a/src/formatters/__tests__/busStopPrediction.test.ts
+++ b/src/formatters/__tests__/busStopPrediction.test.ts
@@ -1,0 +1,233 @@
+import { createMockBusStopPredictionRaw } from '../../services/__mocks__/actRealtimeResponses.js';
+import { createFeedMessage } from '../../services/__mocks__/gtfsRealtimeResponses.js';
+import { createBusStopPredictionsFromActRealtime, createBusStopPredictionsFromGtfsFeed } from '../busStopPrediction.js';
+
+describe('createBusStopPredictionsFromActRealtime', () => {
+    it('returns empty array when no predictions', () => {
+        const result = createBusStopPredictionsFromActRealtime([], true);
+        expect(result).toEqual([]);
+    });
+
+    it('filters by outbound flag, enforces required fields, sorts by arrivalTime', () => {
+        const p1 = createMockBusStopPredictionRaw({
+            rtdir: 'Amtrak', // outbound match (via "amtrak")
+            prdtm: '20240701 12:10',
+            prdctdn: '5',
+            dstp: 123,
+            vid: 'V-OUT-1',
+            tatripid: 'TRIP-OUT-1',
+        });
+        const p2 = createMockBusStopPredictionRaw({
+            rtdir: 'Away', // outbound match (via "away")
+            prdtm: '20240701 12:05',
+            prdctdn: '-2', // negative minutes -> clamped to 0
+            dstp: Number.POSITIVE_INFINITY, // not finite -> null
+            vid: 'V-OUT-2',
+            tatripid: 'TRIP-OUT-2',
+        });
+        const p3 = createMockBusStopPredictionRaw({
+            rtdir: 'Rockridge BART', // inbound (does not include amtrak/away)
+            prdtm: '20240701 12:20',
+            prdctdn: 'Due',
+            vid: 'V-IN-1',
+            tatripid: 'TRIP-IN-1',
+        });
+        const p4 = createMockBusStopPredictionRaw({
+            rtdir: 'Amtrak',
+            prdtm: '20240701 12:00',
+            prdctdn: 'abc', // invalid -> 0
+            dstp: 456,
+            vid: undefined as unknown as string, // missing vid -> filtered out
+            tatripid: 'TRIP-OUT-3',
+        });
+        const p5 = createMockBusStopPredictionRaw({
+            rtdir: 'Amtrak',
+            prdtm: '' as unknown as string, // missing/empty -> filtered out
+            prdctdn: '10',
+            vid: 'V-OUT-3',
+            tatripid: 'TRIP-OUT-4',
+        });
+
+        const result = createBusStopPredictionsFromActRealtime([p1, p2, p3, p4, p5], true);
+
+        // Only p1 and p2 remain (outbound + valid prdtm + vid), sorted by arrivalTime asc (12:05, 12:10)
+        expect(result).toHaveLength(2);
+        expect(result[0].vehicleId).toBe('V-OUT-2');
+        expect(result[0].tripId).toBe('TRIP-OUT-2');
+        expect(result[0].arrivalTime.toISOString()).toBe('2024-07-01T19:05:00.000Z');
+        expect(result[0].departureTime.toISOString()).toBe('2024-07-01T19:05:00.000Z');
+        expect(result[0].minutesAway).toBe(0); // clamped from -2
+        expect(result[0].isOutbound).toBe(true);
+        expect(result[0].distanceToStopFeet).toBeNull(); // Infinity -> null
+
+        expect(result[1].vehicleId).toBe('V-OUT-1');
+        expect(result[1].tripId).toBe('TRIP-OUT-1');
+        expect(result[1].arrivalTime.toISOString()).toBe('2024-07-01T19:10:00.000Z');
+        expect(result[1].departureTime.toISOString()).toBe('2024-07-01T19:10:00.000Z');
+        expect(result[1].minutesAway).toBe(5);
+        expect(result[1].isOutbound).toBe(true);
+        expect(result[1].distanceToStopFeet).toBe(123);
+    });
+
+    it('treats "Due" prdctdn as 0 for outbound predictions', () => {
+        const pDue = createMockBusStopPredictionRaw({
+            rtdir: 'Amtrak',
+            prdtm: '20240701 12:00',
+            prdctdn: 'Due',
+            vid: 'V-DUE',
+            tatripid: 'TRIP-DUE',
+        });
+
+        const result = createBusStopPredictionsFromActRealtime([pDue], true);
+
+        expect(result).toHaveLength(1);
+        expect(result[0].vehicleId).toBe('V-DUE');
+        expect(result[0].tripId).toBe('TRIP-DUE');
+        expect(result[0].minutesAway).toBe(0);
+        expect(result[0].arrivalTime.toISOString()).toBe('2024-07-01T19:00:00.000Z');
+        expect(result[0].departureTime.toISOString()).toBe('2024-07-01T19:00:00.000Z');
+        expect(result[0].isOutbound).toBe(true);
+    });
+
+    it('treats non-numeric prdctdn as 0 when outbound', () => {
+        const pInvalid = createMockBusStopPredictionRaw({
+            rtdir: 'Amtrak',
+            prdtm: '20240701 12:02',
+            prdctdn: 'abc',
+            vid: 'V-INV',
+            tatripid: 'TRIP-INV',
+        });
+
+        const result = createBusStopPredictionsFromActRealtime([pInvalid], true);
+        expect(result).toHaveLength(1);
+        expect(result[0].minutesAway).toBe(0);
+        expect(result[0].arrivalTime.toISOString()).toBe('2024-07-01T19:02:00.000Z');
+    });
+});
+
+describe('createBusStopPredictionsFromGtfsFeed', () => {
+    it('returns empty array when entity is missing', () => {
+        const msg = {} as unknown as Parameters<typeof createBusStopPredictionsFromGtfsFeed>[0];
+        expect(createBusStopPredictionsFromGtfsFeed(msg, true)).toEqual([]);
+    });
+
+    it('flattens stop updates, filters by outbound, ensures times, and sorts by arrivalTime', () => {
+        vi.useFakeTimers();
+        const now = new Date('2025-01-01T00:00:00.000Z');
+        vi.setSystemTime(now);
+        const nowSec = Math.floor(now.getTime() / 1000);
+
+        const feed = createFeedMessage([
+            {
+                id: 'e-outbound',
+                tripUpdate: {
+                    trip: { routeId: '51A', tripId: 'TRIP-1', directionId: 1 },
+                    vehicle: { id: 'V-1' },
+                    stopTimeUpdate: [
+                        // arrival + departure present
+                        {
+                            stopId: 'STOP-1',
+                            arrival: { time: nowSec + 300 }, // 5m
+                            departure: { time: nowSec + 360 }, // 6m
+                        },
+                        // only departure -> arrival should fallback to departure
+                        {
+                            stopId: 'STOP-2',
+                            departure: { time: nowSec + 1200 }, // 20m
+                        },
+                        // arrival in the past -> minutes clamped to 0
+                        {
+                            stopId: 'STOP-3',
+                            arrival: { time: nowSec - 180 }, // -3m
+                        },
+                        // missing/empty stopId -> filtered out
+                        {
+                            stopId: '',
+                            arrival: { time: nowSec + 30 },
+                        },
+                        // no times -> filtered out
+                        {
+                            stopId: 'STOP-X',
+                        },
+                    ],
+                },
+            },
+            {
+                id: 'e-inbound',
+                tripUpdate: {
+                    trip: { routeId: '51A', tripId: 'TRIP-2', directionId: 0 },
+                    vehicle: { id: 'V-2' },
+                    stopTimeUpdate: [{ stopId: 'IN-1', arrival: { time: nowSec + 60 } }],
+                },
+            },
+            // Missing vehicle.id on tripUpdate -> filtered out
+            {
+                id: 'e-missing-vehicle',
+                tripUpdate: {
+                    trip: { routeId: '51A', tripId: 'TRIP-3', directionId: 1 },
+                    stopTimeUpdate: [{ stopId: 'BAD', arrival: { time: nowSec + 10 } }],
+                },
+            },
+        ]);
+
+        const outbound = createBusStopPredictionsFromGtfsFeed(feed, true);
+        expect(outbound.map((o) => o.vehicleId)).toEqual(['V-1', 'V-1', 'V-1']);
+        // Sorted by arrivalTime: STOP-3 (past), STOP-1 (5m), STOP-2 (20m)
+        expect(outbound[0].tripId).toBe('TRIP-1');
+        expect(outbound[0].minutesAway).toBe(0); // clamped from -3
+        expect(outbound[0].arrivalTime.toISOString()).toBe('2024-12-31T23:57:00.000Z');
+        expect(outbound[0].departureTime.toISOString()).toBe('2024-12-31T23:57:00.000Z');
+        expect(outbound[0].isOutbound).toBe(true);
+        expect(outbound[0].distanceToStopFeet).toBeNull();
+
+        expect(outbound[1].arrivalTime.toISOString()).toBe('2025-01-01T00:05:00.000Z');
+        expect(outbound[1].departureTime.toISOString()).toBe('2025-01-01T00:06:00.000Z');
+        expect(outbound[1].minutesAway).toBe(5);
+        expect(outbound[1].isOutbound).toBe(true);
+
+        expect(outbound[2].arrivalTime.toISOString()).toBe('2025-01-01T00:20:00.000Z'); // arrival fallback to departure
+        expect(outbound[2].departureTime.toISOString()).toBe('2025-01-01T00:20:00.000Z');
+        expect(outbound[2].minutesAway).toBe(20);
+        expect(outbound[2].isOutbound).toBe(true);
+
+        const inbound = createBusStopPredictionsFromGtfsFeed(feed, false);
+        expect(inbound).toHaveLength(1);
+        expect(inbound[0].tripId).toBe('TRIP-2');
+        expect(inbound[0].vehicleId).toBe('V-2');
+        expect(inbound[0].minutesAway).toBe(1);
+        expect(inbound[0].isOutbound).toBe(false);
+
+        vi.useRealTimers();
+    });
+
+    it('uses empty string when tripId is missing in GTFS entity', () => {
+        vi.useFakeTimers();
+        const now = new Date('2025-01-02T00:00:00.000Z');
+        vi.setSystemTime(now);
+        const nowSec = Math.floor(now.getTime() / 1000);
+
+        const feed = createFeedMessage([
+            {
+                id: 'e-outbound-no-tripid',
+                tripUpdate: {
+                    trip: { routeId: '51A', directionId: 1 },
+                    vehicle: { id: 'V-NT' },
+                    stopTimeUpdate: [
+                        {
+                            stopId: 'STOP-NT',
+                            arrival: { time: nowSec + 90 },
+                        },
+                    ],
+                },
+            },
+        ]);
+
+        const outbound = createBusStopPredictionsFromGtfsFeed(feed, true);
+        expect(outbound).toHaveLength(1);
+        expect(outbound[0].tripId).toBe('');
+        expect(outbound[0].vehicleId).toBe('V-NT');
+        expect(outbound[0].minutesAway).toBe(2);
+
+        vi.useRealTimers();
+    });
+});

--- a/src/formatters/busPosition.ts
+++ b/src/formatters/busPosition.ts
@@ -1,0 +1,141 @@
+import { transit_realtime } from 'gtfs-realtime-bindings';
+
+import type { BusPositionRaw } from '../services/actRealtime.js';
+import { parseActRealtimeTimestamp } from '../utils/datetime.js';
+
+// https://en.wikipedia.org/wiki/Miles_per_hour
+const MPH_TO_METERS_PER_SECOND = 0.44704;
+
+export interface BusPosition {
+    vehicleId: string;
+    routeId: string;
+    latitude: number;
+    longitude: number;
+    heading: number | null;
+    speed: number | null;
+    timestamp: Date;
+    tripId: string | null;
+    stopSequence: number | null;
+}
+
+function parseFiniteNumber(value: unknown): number | null {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (trimmed.length === 0) {
+            return null;
+        }
+
+        const parsedString = Number(trimmed);
+        return Number.isFinite(parsedString) ? parsedString : null;
+    }
+
+    const parsedNumber = Number(value);
+    return Number.isFinite(parsedNumber) ? parsedNumber : null;
+}
+
+function resolveTimestamp(
+    vehicleTimestamp: transit_realtime.IVehiclePosition['timestamp'],
+    headerTimestamp: transit_realtime.IFeedHeader['timestamp']
+): Date {
+    const seconds = parseFiniteNumber(vehicleTimestamp) ?? parseFiniteNumber(headerTimestamp);
+    return seconds !== null ? new Date(seconds * 1000) : new Date();
+}
+
+export function createBusPositionsFromGtfsFeed(feedMessage: transit_realtime.IFeedMessage): BusPosition[] {
+    if (!feedMessage.entity?.length) {
+        return [];
+    }
+
+    const headerTimestamp = feedMessage.header?.timestamp;
+
+    const positions = feedMessage.entity.flatMap((entity) => {
+        const vehicle = entity.vehicle;
+        if (!vehicle) {
+            return [];
+        }
+
+        const routeId = vehicle.trip?.routeId;
+        const latitude = parseFiniteNumber(vehicle.position?.latitude);
+        const longitude = parseFiniteNumber(vehicle.position?.longitude);
+        const vehicleId = vehicle.vehicle?.id ?? entity.id /* v8 ignore next */ ?? '';
+
+        if (!routeId || latitude === null || longitude === null || !vehicleId) {
+            return [];
+        }
+
+        const stopSequenceValue = parseFiniteNumber(vehicle.currentStopSequence);
+
+        const position: BusPosition = {
+            vehicleId,
+            routeId,
+            latitude,
+            longitude,
+            heading: parseFiniteNumber(vehicle.position?.bearing),
+            speed: parseFiniteNumber(vehicle.position?.speed),
+            timestamp: resolveTimestamp(vehicle.timestamp, headerTimestamp),
+            tripId: vehicle.trip?.tripId ?? null,
+            stopSequence: stopSequenceValue !== null ? Math.round(stopSequenceValue) : null,
+        };
+
+        return [position];
+    });
+
+    return positions.sort((a, b) => a.vehicleId.localeCompare(b.vehicleId));
+}
+
+function resolveTripId(raw: BusPositionRaw): string | null {
+    const trimmedStringTripId = raw.tatripid?.trim();
+    if (trimmedStringTripId) {
+        return trimmedStringTripId;
+    }
+
+    if (raw.tripid !== undefined && raw.tripid !== null) {
+        return String(raw.tripid);
+    }
+
+    return null;
+}
+
+export function createBusPositionsFromActRealtime(rawPositions: Array<BusPositionRaw>): BusPosition[] {
+    if (!rawPositions?.length) {
+        return [];
+    }
+
+    const positions = rawPositions
+        .map((rawPosition) => {
+            const vehicleId = rawPosition.vid?.trim();
+            const routeId = rawPosition.rt?.trim();
+            const latitude = parseFiniteNumber(rawPosition.lat);
+            const longitude = parseFiniteNumber(rawPosition.lon);
+
+            if (!vehicleId || !routeId || latitude === null || longitude === null) {
+                return null;
+            }
+
+            const heading = parseFiniteNumber(rawPosition.hdg);
+            const speedMph = parseFiniteNumber(rawPosition.spd);
+            const speed = speedMph !== null ? speedMph * MPH_TO_METERS_PER_SECOND : null;
+
+            const position: BusPosition = {
+                vehicleId,
+                routeId,
+                latitude,
+                longitude,
+                heading,
+                speed,
+                timestamp: parseActRealtimeTimestamp(rawPosition.tmstmp),
+                tripId: resolveTripId(rawPosition),
+                stopSequence: null, // ACT RealTime does not provide stop sequence information
+            };
+
+            return position;
+        })
+        .filter((position): position is BusPosition => position !== null)
+        .sort((a, b) => a.vehicleId.localeCompare(b.vehicleId));
+
+    return positions;
+}

--- a/src/formatters/busStop.ts
+++ b/src/formatters/busStop.ts
@@ -1,0 +1,30 @@
+import type { BusStopProfileRaw } from '../services/actRealtime.js';
+
+/**
+ * Structured bus stop profile data
+ */
+export type BusStopProfile = {
+    id: string; // GTFS stop_id (geoid from API)
+    code: string; // 5-digit stop code (stpid from API)
+    latitude: number; // Stop latitude
+    longitude: number; // Stop longitude
+    name: string; // Stop name
+};
+
+export function createBusStopProfile(rawBusStop: BusStopProfileRaw): BusStopProfile {
+    if (!rawBusStop.geoid) {
+        throw new Error('Cannot create BusStopProfile without geoid');
+    }
+
+    if (!rawBusStop.stpid) {
+        throw new Error('Cannot create BusStopProfile without stpid');
+    }
+
+    return {
+        id: rawBusStop.geoid,
+        code: rawBusStop.stpid,
+        latitude: rawBusStop.lat,
+        longitude: rawBusStop.lon,
+        name: rawBusStop.stpnm,
+    };
+}

--- a/src/formatters/busStopPrediction.ts
+++ b/src/formatters/busStopPrediction.ts
@@ -1,0 +1,115 @@
+import { type transit_realtime } from 'gtfs-realtime-bindings';
+
+import type { BusStopPredictionRaw } from '../services/actRealtime.js';
+import { parseActRealtimeTimestamp } from '../utils/datetime.js';
+
+export interface BusStopPrediction {
+    vehicleId: string;
+    tripId: string;
+    arrivalTime: Date;
+    departureTime: Date;
+    minutesAway: number;
+    isOutbound: boolean;
+    distanceToStopFeet: number | null;
+}
+
+function parseMinutesAway(value: string): number {
+    if (value === 'Due') {
+        return 0;
+    }
+
+    const parsed = Number.parseInt(value, 10);
+    return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function isOutboundDirection(direction: string): boolean {
+    const normalized = direction.toLowerCase();
+    return normalized.includes('amtrak') || normalized.includes('away');
+}
+
+/**
+ * Avoids returning negative minutes away
+ */
+function formatMinutesAway(arrivalUnixTime: number): number {
+    return Math.max(0, arrivalUnixTime);
+}
+
+export function createBusStopPredictionsFromActRealtime(
+    rawPredictions: BusStopPredictionRaw[],
+    isOutbound: boolean
+): BusStopPrediction[] {
+    if (!rawPredictions?.length) {
+        return [];
+    }
+
+    return rawPredictions
+        .filter(
+            (prediction) => isOutboundDirection(prediction.rtdir) === isOutbound && prediction.prdtm && prediction.vid
+        )
+        .map((prediction) => {
+            const arrivalTime = parseActRealtimeTimestamp(prediction.prdtm);
+            const minutesAway = parseMinutesAway(prediction.prdctdn);
+
+            return {
+                vehicleId: prediction.vid,
+                tripId: prediction.tatripid,
+                arrivalTime,
+                departureTime: arrivalTime,
+                minutesAway: formatMinutesAway(minutesAway),
+                isOutbound: isOutboundDirection(prediction.rtdir),
+                distanceToStopFeet: Number.isFinite(prediction.dstp) ? prediction.dstp : null,
+            };
+        })
+        .sort((a, b) => a.arrivalTime.getTime() - b.arrivalTime.getTime());
+}
+
+export function createBusStopPredictionsFromGtfsFeed(
+    feedMessage: transit_realtime.IFeedMessage,
+    isOutbound: boolean
+): BusStopPrediction[] {
+    if (!feedMessage.entity) return [];
+
+    // Flatten all stop time updates with their trip context
+    const allStopUpdates: BusStopPrediction[] = feedMessage.entity
+        .filter(
+            (entity) =>
+                entity.tripUpdate?.trip?.routeId && entity.tripUpdate?.stopTimeUpdate && entity.tripUpdate?.vehicle?.id
+        )
+        .flatMap((entity) => {
+            const tripUpdate = entity.tripUpdate!;
+            const trip = tripUpdate.trip;
+            const tripIsOutbound = trip.directionId === 1; // GTFS directionId: 1=outbound (Amtrak), 0=inbound (Rockridge BART)
+            const vehicleId = tripUpdate.vehicle!.id as string;
+
+            return tripUpdate
+                .stopTimeUpdate!.filter(
+                    (stopTimeUpdate) =>
+                        stopTimeUpdate.stopId &&
+                        // Ensure at least one of arrival or departure times is present
+                        (stopTimeUpdate.arrival?.time || stopTimeUpdate.departure?.time) &&
+                        tripIsOutbound === isOutbound
+                )
+                .map((stopTimeUpdate) => {
+                    const arrivalUnixTime = stopTimeUpdate.arrival?.time;
+                    const departureUnixTime = stopTimeUpdate.departure?.time;
+
+                    const arrivalTime = new Date(Number(arrivalUnixTime || departureUnixTime) * 1000);
+                    const departureTime = new Date(Number(departureUnixTime || arrivalUnixTime) * 1000);
+
+                    const now = new Date();
+                    const minutesAway = Math.round((arrivalTime.getTime() - now.getTime()) / 60000);
+
+                    return {
+                        tripId: trip.tripId || '',
+                        vehicleId,
+                        isOutbound: tripIsOutbound,
+                        arrivalTime,
+                        departureTime,
+                        minutesAway: formatMinutesAway(minutesAway),
+                        distanceToStopFeet: null, // GTFS-RT doesn't provide distance data
+                    };
+                });
+        });
+
+    return allStopUpdates.sort((a, b) => a.arrivalTime.getTime() - b.arrivalTime.getTime());
+}

--- a/src/utils/__tests__/datetime.test.ts
+++ b/src/utils/__tests__/datetime.test.ts
@@ -1,0 +1,167 @@
+import { parseActRealtimeTimestamp } from '../datetime.js';
+
+describe('parseActRealtimeTimestamp', () => {
+    it('parses a PDT timestamp to the correct UTC time', () => {
+        const result = parseActRealtimeTimestamp('20240701 12:34');
+        expect(result.toISOString()).toBe('2024-07-01T19:34:00.000Z');
+    });
+
+    it('parses a PST timestamp to the correct UTC time', () => {
+        const result = parseActRealtimeTimestamp('20240115 08:15');
+        expect(result.toISOString()).toBe('2024-01-15T16:15:00.000Z');
+    });
+
+    it('defaults minutes to 00 when omitted', () => {
+        const result = parseActRealtimeTimestamp('20240701 09');
+        expect(result.toISOString()).toBe('2024-07-01T16:00:00.000Z');
+    });
+
+    it.each<[string | undefined]>([
+        [undefined],
+        [''],
+        ['20240101'],
+        ['20240132 00:00'], // invalid day
+        ['20240101 24:00'], // invalid hour
+        ['20240101 12:60'], // invalid minute
+        ['20240701 ab:00'], // non-numeric hour
+    ])('falls back to current time and warns for invalid input: %p', (input) => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const result = parseActRealtimeTimestamp(input as unknown as string | undefined);
+
+        expect(result.toISOString()).toBe('2025-01-01T00:00:00.000Z');
+        expect(warnSpy).toHaveBeenCalledWith(`Invalid ACT RealTime timestamp: ${input}`);
+
+        warnSpy.mockRestore();
+        vi.useRealTimers();
+    });
+
+    it('handles DST start boundary (pre-DST PST)', () => {
+        // Before DST starts (PST, UTC-8)
+        const result = parseActRealtimeTimestamp('20240310 01:30');
+        expect(result.toISOString()).toBe('2024-03-10T09:30:00.000Z');
+    });
+
+    it('handles DST start boundary (post-DST PDT)', () => {
+        // After DST starts (PDT, UTC-7)
+        const result = parseActRealtimeTimestamp('20240310 03:30');
+        expect(result.toISOString()).toBe('2024-03-10T10:30:00.000Z');
+    });
+
+    it('handles DST end boundary (ambiguous 01:30 resolves to PDT)', () => {
+        // Before fallback occurs at 2:00 local; choose PDT (-7)
+        const result = parseActRealtimeTimestamp('20241103 01:30');
+        expect(result.toISOString()).toBe('2024-11-03T08:30:00.000Z');
+    });
+
+    it('uses legacy abbreviation offsets when provided (PDT)', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(() => [{ type: 'timeZoneName', value: 'PDT' }] as unknown as Intl.DateTimeFormatPart[]);
+
+        const result = parseActRealtimeTimestamp('20240701 00:00');
+        expect(result.toISOString()).toBe('2024-07-01T07:00:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('uses legacy abbreviation offsets when provided (PST)', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(() => [{ type: 'timeZoneName', value: 'PST' }] as unknown as Intl.DateTimeFormatPart[]);
+
+        const result = parseActRealtimeTimestamp('20240115 00:00');
+        expect(result.toISOString()).toBe('2024-01-15T08:00:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('treats unsupported abbreviation as zero offset', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(() => [{ type: 'timeZoneName', value: 'XXX' }] as unknown as Intl.DateTimeFormatPart[]);
+
+        const result = parseActRealtimeTimestamp('20240701 12:34');
+        expect(result.toISOString()).toBe('2024-07-01T12:34:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('treats missing timeZoneName as zero offset', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(() => [{ type: 'year', value: '2024' }] as unknown as Intl.DateTimeFormatPart[]);
+
+        const result = parseActRealtimeTimestamp('20240701 12:34');
+        expect(result.toISOString()).toBe('2024-07-01T12:34:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('treats bare UTC name as zero offset via regex path', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(() => [{ type: 'timeZoneName', value: 'UTC' }] as unknown as Intl.DateTimeFormatPart[]);
+
+        const result = parseActRealtimeTimestamp('20240701 12:00');
+        expect(result.toISOString()).toBe('2024-07-01T12:00:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('parses positive offset with minutes (UTC+05:30)', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(
+                () => [{ type: 'timeZoneName', value: 'UTC+05:30' }] as unknown as Intl.DateTimeFormatPart[]
+            );
+
+        const result = parseActRealtimeTimestamp('20240701 12:00');
+        // localTimestamp is 12:00Z; subtracting +05:30 yields 06:30Z
+        expect(result.toISOString()).toBe('2024-07-01T06:30:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('parses positive offset without minutes (UTC+05)', () => {
+        const spy = vi
+            .spyOn(Intl.DateTimeFormat.prototype, 'formatToParts')
+            .mockImplementation(
+                () => [{ type: 'timeZoneName', value: 'UTC+05' }] as unknown as Intl.DateTimeFormatPart[]
+            );
+
+        const result = parseActRealtimeTimestamp('20240701 12:00');
+        // localTimestamp is 12:00Z; subtracting +05:00 yields 07:00Z
+        expect(result.toISOString()).toBe('2024-07-01T07:00:00.000Z');
+
+        spy.mockRestore();
+    });
+
+    it('falls back to current time when Date.UTC returns NaN', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-02-01T00:00:00.000Z'));
+
+        const utcSpy = vi.spyOn(Date, 'UTC').mockReturnValue(Number.NaN as unknown as number);
+        const result = parseActRealtimeTimestamp('20240701 12:34');
+
+        expect(result.toISOString()).toBe('2025-02-01T00:00:00.000Z');
+
+        utcSpy.mockRestore();
+        vi.useRealTimers();
+    });
+
+    it('falls back at final NaN check when getTime is NaN', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2025-03-01T00:00:00.000Z'));
+
+        const getTimeSpy = vi.spyOn(Date.prototype, 'getTime').mockReturnValue(Number.NaN);
+        const result = parseActRealtimeTimestamp('20240701 12:34');
+
+        expect(result.toISOString()).toBe('2025-03-01T00:00:00.000Z');
+
+        getTimeSpy.mockRestore();
+        vi.useRealTimers();
+    });
+});

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,132 @@
+const ACT_REALTIME_TIME_ZONE = 'America/Los_Angeles';
+const MS_PER_MINUTE = 60 * 1000;
+
+const actTimeZoneFormatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: ACT_REALTIME_TIME_ZONE,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    timeZoneName: 'shortOffset',
+});
+
+const LEGACY_TZ_ABBREVIATION_OFFSETS: Record<string, number> = {
+    PDT: -7 * 60,
+    PST: -8 * 60,
+};
+
+/**
+ * Gets the timezone offset in minutes for a given date.
+ * @param date The date to get the timezone offset for.
+ * @returns The timezone offset in minutes.
+ */
+function getTimezoneOffsetMinutes(date: Date): number {
+    const parts = actTimeZoneFormatter.formatToParts(date);
+    const timeZoneName = parts.find((part) => part.type === 'timeZoneName')?.value;
+
+    if (!timeZoneName) {
+        return 0;
+    }
+
+    const match = timeZoneName.match(/^(?:GMT|UTC)(?:(\+|-)(\d{1,2})(?::?(\d{2}))?)?$/);
+
+    if (match) {
+        const sign = match[1] === '-' ? -1 : 1;
+        const hours = Number(match[2] ?? '0');
+        const minutes = Number(match[3] ?? '0');
+
+        return sign * (hours * 60 + minutes);
+    }
+
+    const legacyOffset = LEGACY_TZ_ABBREVIATION_OFFSETS[timeZoneName];
+
+    return typeof legacyOffset === 'number' ? legacyOffset : 0;
+}
+
+function safeNumber(value: string): number | null {
+    const parsed = Number.parseInt(value, 10);
+
+    return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * Converts an ACT RealTime timestamp (`YYYYMMDD HH:MM`) into a JavaScript `Date`
+ * using the America/Los_Angeles timezone to avoid environment-dependent skew.
+ * Falls back to the current time when the input is missing or malformed.
+ */
+export function parseActRealtimeTimestamp(value?: string): Date {
+    const [datePart, timePart] = value?.split(' ') ?? [];
+
+    // Fall back to current time if the input is missing or malformed
+    if (!datePart || !timePart || datePart.length !== 8) {
+        console.warn(`Invalid ACT RealTime timestamp: ${value}`);
+        return new Date();
+    }
+
+    const year = safeNumber(datePart.substring(0, 4));
+    const month = safeNumber(datePart.substring(4, 6));
+    const day = safeNumber(datePart.substring(6, 8));
+
+    const [hourPart = '00', minutePart = '00'] = timePart.split(':');
+    const hour = safeNumber(hourPart);
+    const minute = safeNumber(minutePart);
+
+    // Validate ranges and fall back to current time if out of range
+    if (
+        year === null ||
+        month === null ||
+        day === null ||
+        hour === null ||
+        minute === null ||
+        month < 1 ||
+        month > 12 ||
+        day < 1 ||
+        day > 31 ||
+        hour < 0 ||
+        hour > 23 ||
+        minute < 0 ||
+        minute > 59
+    ) {
+        console.warn(`Invalid ACT RealTime timestamp: ${value}`);
+        return new Date();
+    }
+
+    /**
+     * We have to manually adjust for timezone offsets because the Date constructor
+     * and Date.parse() treat input as local time or UTC depending on the format
+     * and environment, which leads to inconsistent results.
+     *
+     * The approach here is to:
+     * 1. Construct a timestamp as if the input were in UTC (ignoring timezone)
+     * 2. Get the timezone offset for that timestamp in the target timezone
+     * 3. Adjust the timestamp by that offset
+     * 4. Repeat steps 2-3 until the offset stabilizes (handles DST transitions)
+     *
+     * This effectively simulates constructing the date in the target timezone.
+     */
+    const localTimestamp = Date.UTC(year, month - 1, day, hour, minute);
+
+    if (Number.isNaN(localTimestamp)) {
+        return new Date();
+    }
+
+    let timestamp = localTimestamp;
+
+    for (let i = 0; i < 2; i += 1) {
+        const offsetMinutes = getTimezoneOffsetMinutes(new Date(timestamp));
+        const adjusted = localTimestamp - offsetMinutes * MS_PER_MINUTE;
+
+        if (adjusted === timestamp) {
+            break;
+        }
+
+        timestamp = adjusted;
+    }
+
+    const parsedDate = new Date(timestamp);
+
+    return Number.isNaN(parsedDate.getTime()) ? new Date() : parsedDate;
+}


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the formatter functions that process bus positions, bus stop profiles, and bus stop predictions from both ACT Realtime and GTFS feeds. The tests cover a wide range of scenarios, including valid and invalid data, edge cases, and fallback logic, ensuring robust and predictable behavior of the formatter functions.

### Bus Position Formatter Tests

* Added tests for `createBusPositionsFromActRealtime` and `createBusPositionsFromGtfsFeed`, verifying parsing, conversion of units, tripId resolution, sorting, filtering of invalid entries, and handling of edge cases like missing or non-finite values.

### Bus Stop Profile Formatter Tests

* Added tests for `createBusStopProfile`, ensuring correct mapping from raw data to structured profiles and enforcing required fields (`geoid` and `stpid`), with error handling for missing data.

### Bus Stop Prediction Formatter Tests

* Added tests for `createBusStopPredictionsFromActRealtime` and `createBusStopPredictionsFromGtfsFeed`, covering filtering by outbound/inbound, required field enforcement, sorting, handling of time calculations, fallback logic for missing or invalid fields, and clamping of negative/invalid values.