### PR TITLE
integrate services to gql context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -2,15 +2,24 @@ import type { YogaInitialContext } from 'graphql-yoga';
 
 import type { Env } from './env.js';
 import { env } from './env.js';
+import type { ACTRealtimeServiceType } from './services/actRealtime.js';
+import type { GTFSRealtimeServiceType } from './services/gtfsRealtime.js';
 
-export interface GraphQLContext {
+export type Services = {
+    actRealtime: ACTRealtimeServiceType;
+    gtfsRealtime: GTFSRealtimeServiceType;
+};
+export interface GraphQLContext extends YogaInitialContext {
     env: Env;
-    request: YogaInitialContext['request'];
+    services: Services;
 }
 
-export async function createContext(initialContext: YogaInitialContext): Promise<GraphQLContext> {
-    return {
-        env,
-        request: initialContext.request,
+export function createContextFactory(services: Services) {
+    return async function createContext(initialContext: YogaInitialContext): Promise<GraphQLContext> {
+        return {
+            ...initialContext,
+            env,
+            services,
+        };
     };
 }

--- a/src/mocks/context.ts
+++ b/src/mocks/context.ts
@@ -1,6 +1,10 @@
 import { createMockEnv } from './env.js';
 
 import type { GraphQLContext } from '../context.js';
+import { createACTRealtimeService } from '../services/actRealtime.js';
+import { createGTFSRealtimeService } from '../services/gtfsRealtime.js';
+import { getCachedOrFetch } from '../utils/cache.js';
+import { fetchWithUrlParams } from '../utils/fetch.js';
 
 export const createMockContext = (overrides?: Partial<GraphQLContext>): GraphQLContext => {
     // Create default mock request if not provided
@@ -13,9 +17,39 @@ export const createMockContext = (overrides?: Partial<GraphQLContext>): GraphQLC
         }),
     });
 
+    const mockEnv = createMockEnv();
+
+    const actRealtime = createACTRealtimeService({
+        fetchWithUrlParams,
+        apiToken: mockEnv.AC_TRANSIT_TOKEN,
+        apiBaseUrl: mockEnv.ACT_REALTIME_API_BASE_URL,
+        cacheTtl: {
+            busStopProfiles: mockEnv.WHERE_IS_51B_CACHE_TTL_BUS_STOP_PROFILES,
+            predictions: mockEnv.WHERE_IS_51B_CACHE_TTL_PREDICTIONS,
+            vehiclePositions: mockEnv.WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS,
+        },
+        getCachedOrFetch,
+    });
+
+    const gtfsRealtime = createGTFSRealtimeService({
+        fetchWithUrlParams,
+        apiToken: mockEnv.AC_TRANSIT_TOKEN,
+        apiBaseUrl: mockEnv.GTFS_REALTIME_API_BASE_URL,
+        cacheTtl: {
+            vehiclePositions: mockEnv.WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS,
+            tripUpdates: mockEnv.WHERE_IS_51B_CACHE_TTL_PREDICTIONS,
+            serviceAlerts: mockEnv.WHERE_IS_51B_CACHE_TTL_SERVICE_ALERTS,
+        },
+        getCachedOrFetch,
+    });
+
     return {
         request: defaultRequest,
-        env: createMockEnv(),
+        env: mockEnv,
+        services: {
+            actRealtime,
+            gtfsRealtime,
+        },
         ...overrides,
-    };
+    } as GraphQLContext;
 };


### PR DESCRIPTION
This pull request refactors how services are injected into the GraphQL context, improving modularity and testability. The main change is introducing a `services` object containing the `actRealtime` and `gtfsRealtime` services, which is now provided to the context via a factory function. This approach makes it easier to mock services and manage dependencies across the codebase.

**GraphQL context refactor and dependency injection:**

* Changed `GraphQLContext` to include a `services` property containing `actRealtime` and `gtfsRealtime` service instances, replacing direct instantiation within the context. (`src/context.ts`)
* Added a `createContextFactory` function that takes a `services` object and returns an async context creator, enabling dependency injection for services. (`src/context.ts`)

**Server initialization updates:**

* Created the `services` object in `src/server.ts` by instantiating `actRealtime` and `gtfsRealtime` with environment variables and utility functions, then passed it to `createContextFactory` for context creation in the GraphQL server. (`src/server.ts`) [[1]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595L9-R15) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R25-R52)

**Testing and mocks improvements:**

* Updated `createMockContext` in `src/mocks/context.ts` to mock the `services` object using mock environment values and utility functions, ensuring tests use isolated service instances. (`src/mocks/context.ts`) [[1]](diffhunk://#diff-c580f636f8b6be76f538d622282e23ebfc53df49ade99e12288a324db36210c8R4-R7) [[2]](diffhunk://#diff-c580f636f8b6be76f538d622282e23ebfc53df49ade99e12288a324db36210c8R20-R54)