### PR TITLE
add script to auto scaffold new gql type

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,46 @@ Unified GraphQL Yoga server merging multiple internal services into a single sch
 
 #### New schema types and resolvers
 
-- Create new directory under `src/schema`
-- Create schema (typeDefs) in `src/schema/new-type-name/new-type-name.schema.ts`
-- Create resolvers in `src/schema/new-type-name/new-type-name.resolvers.ts`
-- Create index file to export schema and resolvers in `src/schema/new-type-name/index.ts`
-- Import new schema and resolvers in `src/schema/index.ts`
-- Run codegen `pnpm codegen` to generate types
+Use the generator to scaffold and integrate a new GraphQL type.
+
+1. Run the generator
+
+    ```bash
+    pnpm generate:type
+    ```
+
+    - Enter the Type name in PascalCase (e.g., `NewType`).
+    - Enter a short description for the type (used in GraphQL docstrings).
+
+2. What it creates
+
+    For `NewType`, the generator creates:
+    - `src/schema/newType/newType.schema.ts` — Schema with type docstring and a placeholder field.
+    - `src/schema/newType/newType.resolver.ts` — Parent type scaffold and placeholder resolver.
+    - `src/schema/newType/index.ts` — Exports `<name>Defs` and `<name>Resolvers`.
+
+3. Automatic integration
+
+    The generator updates `src/schema/index.ts` to:
+    - Add an import: `import { newTypeDefs, newTypeResolvers } from './newType/index.js';`
+    - Append `newTypeDefs` to `mergeTypeDefs([...])`.
+    - Insert `newTypeResolvers` in the Domain-specific resolvers block before `rootResolvers`.
+    - Alphabetize the list of typeDefs (keeping `rootTypeDefs` first) and domain resolvers.
+
+4. Formatting and linting
+
+    After scaffolding, it runs Prettier and ESLint on the new files and `src/schema/index.ts`.
+
+5. Next steps (manual)
+    - Replace the placeholder field with real fields and ensure every type/field has a GraphQL docstring.
+    - Flesh out the parent type and resolvers; implement any data fetching needed.
+    - If the new type should be reachable from `Query`, `Mutation`, or `Subscription`, update the root schema/resolvers accordingly.
+    - When the schema is valid, run `pnpm codegen` to refresh generated TypeScript types.
+
+Notes
+
+- If a directory for the chosen type already exists, the generator will exit to avoid overwriting; remove the directory or choose another name.
+- The generator doesn’t execute codegen automatically because freshly scaffolded types may not be valid yet.
+- ESLint may report `@graphql-eslint/no-unreachable-types` for the new type until it is reachable from
+  `Query`, `Mutation`, `Subscription`, or another type. This is expected. Even if ESLint exits with a non‑zero code, it
+  still applies autofixes such as import ordering to the changed files.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "format": "prettier --write .",
         "test": "vitest run --coverage",
         "prepare": "husky || true",
-        "codegen": "graphql-codegen --config codegen.ts"
+        "codegen": "graphql-codegen --config codegen.ts",
+        "generate:type": "tsx scripts/generate-type.ts"
     },
     "lint-staged": {
         "**/*.{ts,tsx}": [

--- a/scripts/generate-type.ts
+++ b/scripts/generate-type.ts
@@ -1,3 +1,7 @@
+/**
+ * Script to scaffold a new GraphQL type with schema, resolver, and index files.
+ */
+
 import { spawn } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';

--- a/scripts/generate-type.ts
+++ b/scripts/generate-type.ts
@@ -1,0 +1,247 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { stdin as input, stdout as output } from 'node:process';
+import { createInterface } from 'node:readline/promises';
+
+function toPascalCase(value: string): string {
+    const words = value
+        .trim()
+        .replace(/[^A-Za-z0-9]+/g, ' ')
+        .split(' ')
+        .filter(Boolean);
+    const joined = words.map((w) => w[0]?.toUpperCase() + w.slice(1)).join('');
+    return joined || 'NewType';
+}
+
+function lowerFirst(value: string): string {
+    return value ? value[0].toLowerCase() + value.slice(1) : value;
+}
+
+function makeSchemaContent(typeName: string, typeDescription: string, camelName: string): string {
+    const defsConst = `${camelName}Defs`;
+    return `export const ${defsConst} = /* GraphQL */ \`
+    """
+    ${typeDescription}
+    """
+    type ${typeName} {
+        """
+        Placeholder field for ${typeName}
+        """
+        placeholder: String!
+    }
+\`;
+`;
+}
+
+function makeResolverContent(typeName: string, camelName: string): string {
+    const resolversConst = `${camelName}Resolvers`;
+    return `import type { GraphQLContext } from '../../context.js';
+
+export type ${typeName}Parent = {
+    __typename: '${typeName}';
+    placeholder: string;
+};
+
+export function create${typeName}Parent(data: Partial<${typeName}Parent> = {}): ${typeName}Parent {
+    return {
+        __typename: '${typeName}',
+        placeholder: data.placeholder ?? 'TODO',
+        ...data,
+    };
+}
+
+export const ${resolversConst} = {
+    ${typeName}: {
+        placeholder: (parent: ${typeName}Parent, _args: unknown, _ctx: GraphQLContext) => parent.placeholder ?? 'TODO',
+    },
+};
+`;
+}
+
+function makeIndexContent(camelName: string): string {
+    const defsConst = `${camelName}Defs`;
+    const resolversConst = `${camelName}Resolvers`;
+    return `export { ${defsConst} } from './${camelName}.schema.js';
+export { ${resolversConst} } from './${camelName}.resolver.js';
+`;
+}
+
+async function ensureDir(dir: string) {
+    try {
+        await fs.mkdir(dir, { recursive: false });
+    } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+            throw new Error(`Directory already exists: ${dir}`);
+        }
+        throw err;
+    }
+}
+
+async function integrateIntoSchemaIndex(camelName: string) {
+    const schemaIndexPath = path.join('src', 'schema', 'index.ts');
+    let content = await fs.readFile(schemaIndexPath, 'utf8');
+
+    const importLine = `import { ${camelName}Defs, ${camelName}Resolvers } from './${camelName}/index.js';`;
+    if (!content.includes(`'./${camelName}/index.js'`) && !content.includes(`"./${camelName}/index.js"`)) {
+        // Insert after the last import line
+        const lines = content.split('\n');
+        let lastImportIdx = -1;
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].startsWith('import ')) lastImportIdx = i;
+        }
+        if (lastImportIdx >= 0) {
+            lines.splice(lastImportIdx + 1, 0, importLine);
+            content = lines.join('\n');
+        } else {
+            // Fallback: prepend
+            content = `${importLine}\n${content}`;
+        }
+    }
+
+    // Add to mergeTypeDefs([...])
+    const typeDefsMarker = 'const typeDefs = mergeTypeDefs([';
+    const typeDefsIdx = content.indexOf(typeDefsMarker);
+    if (typeDefsIdx === -1) throw new Error('Could not find typeDefs declaration in src/schema/index.ts');
+    const typeDefsEndIdx = content.indexOf(']);', typeDefsIdx);
+    if (typeDefsEndIdx === -1) throw new Error('Could not find end of typeDefs merge in src/schema/index.ts');
+    const typeDefsSegment = content.slice(typeDefsIdx, typeDefsEndIdx);
+    if (!typeDefsSegment.includes(`${camelName}Defs`)) {
+        content = content.slice(0, typeDefsEndIdx) + `, ${camelName}Defs` + content.slice(typeDefsEndIdx);
+    }
+
+    // Add to mergeResolvers([...])
+    const resolversMarker = 'const resolvers = mergeResolvers([';
+    const resolversIdx = content.indexOf(resolversMarker);
+    if (resolversIdx === -1) throw new Error('Could not find resolvers declaration in src/schema/index.ts');
+    const resolversEndIdx = content.indexOf(']);', resolversIdx);
+    if (resolversEndIdx === -1) throw new Error('Could not find end of resolvers merge in src/schema/index.ts');
+    const resolversSegment = content.slice(resolversIdx, resolversEndIdx);
+    if (!resolversSegment.includes(`${camelName}Resolvers`)) {
+        let updatedSegment: string;
+        if (resolversSegment.includes('rootResolvers,')) {
+            // Insert before rootResolvers inside the array segment only
+            updatedSegment = resolversSegment.replace(
+                'rootResolvers,',
+                `    ${camelName}Resolvers,\n    rootResolvers,`
+            );
+        } else {
+            // Append to the end of the array segment
+            updatedSegment = resolversSegment + `\n    ${camelName}Resolvers,`;
+        }
+        // Rebuild content with the updated resolvers array segment
+        content = content.slice(0, resolversIdx) + updatedSegment + content.slice(resolversEndIdx);
+    }
+
+    // After insertion, alphabetize typeDefs and domain-specific resolvers
+    content = sortTypeDefsAlphabetically(content);
+    content = sortDomainResolversAlphabetically(content);
+
+    await fs.writeFile(schemaIndexPath, content, 'utf8');
+}
+
+function sortTypeDefsAlphabetically(content: string): string {
+    const regex = /const typeDefs = mergeTypeDefs\(\[([\s\S]*?)\]\);/;
+    const match = content.match(regex);
+    if (!match) return content;
+    const body = match[1];
+    const items = Array.from(new Set(body.match(/[A-Za-z0-9_]+Defs/g) || []));
+    if (items.length === 0) return content;
+
+    const hasRoot = items.includes('rootTypeDefs');
+    const sorted = items.filter((x) => x !== 'rootTypeDefs').sort((a, b) => a.localeCompare(b));
+    const newItems = hasRoot ? ['rootTypeDefs', ...sorted] : sorted;
+    const replacement = `const typeDefs = mergeTypeDefs([${newItems.join(', ')}]);`;
+    return content.replace(regex, replacement);
+}
+
+function sortDomainResolversAlphabetically(content: string): string {
+    const arrayRegex = /const resolvers = mergeResolvers\(\[([\s\S]*?)\]\);/;
+    const arrayMatch = content.match(arrayRegex);
+    if (!arrayMatch) return content;
+    const arrayBody = arrayMatch[1];
+
+    // Find domain-specific block up to rootResolvers
+    const domainRegex = /(\/\/ Domain-specific resolvers\s*)([\s\S]*?)(\s*rootResolvers,)/;
+    const domainMatch = arrayBody.match(domainRegex);
+    if (!domainMatch) return content; // If format changes, skip sorting safely
+
+    const domainBody = domainMatch[2];
+    const names = Array.from(
+        new Set((domainBody.match(/([A-Za-z0-9_]+Resolvers),/g) || []).map((s) => s.replace(',', '')))
+    );
+    if (names.length <= 1) return content; // Nothing to sort
+
+    const sorted = names.sort((a, b) => a.localeCompare(b));
+    const indent = '    ';
+    const rebuilt = domainMatch[1] + sorted.map((n) => `${indent}${n},`).join('\n') + domainMatch[3];
+    const newArrayBody = arrayBody.replace(domainRegex, rebuilt);
+    const replacement = `const resolvers = mergeResolvers([${newArrayBody}]);`;
+    return content.replace(arrayRegex, replacement);
+}
+
+function run(cmd: string, args: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(cmd, args, { stdio: 'inherit' });
+        child.on('error', reject);
+        child.on('exit', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`${cmd} ${args.join(' ')} exited with code ${code}`));
+        });
+    });
+}
+
+async function formatAndLint(files: string[]): Promise<void> {
+    if (!files.length) return;
+    try {
+        await run('pnpm', ['exec', 'prettier', '--write', ...files]);
+    } catch (err) {
+        console.warn('Prettier failed:', err instanceof Error ? err.message : err);
+    }
+    try {
+        await run('pnpm', ['exec', 'eslint', '--fix', ...files]);
+    } catch (err) {
+        console.warn('ESLint failed:', err instanceof Error ? err.message : err);
+    }
+}
+
+async function main() {
+    const rl = createInterface({ input, output });
+    try {
+        const rawTypeName = (await rl.question('Type name (PascalCase, e.g., NewType): ')).trim();
+        const typeDescription = (await rl.question('Type description: ')).trim() || 'Describe this type';
+
+        const typeName = toPascalCase(rawTypeName || 'NewType');
+        const camelName = lowerFirst(typeName);
+        const baseDir = path.join('src', 'schema', camelName);
+        const schemaPath = path.join(baseDir, `${camelName}.schema.ts`);
+        const resolverPath = path.join(baseDir, `${camelName}.resolver.ts`);
+        const indexPath = path.join(baseDir, `index.ts`);
+
+        await ensureDir(baseDir);
+
+        const schemaContent = makeSchemaContent(typeName, typeDescription, camelName);
+        const resolverContent = makeResolverContent(typeName, camelName);
+        const indexContent = makeIndexContent(camelName);
+
+        await fs.writeFile(schemaPath, schemaContent, 'utf8');
+        await fs.writeFile(resolverPath, resolverContent, 'utf8');
+        await fs.writeFile(indexPath, indexContent, 'utf8');
+
+        await integrateIntoSchemaIndex(camelName);
+
+        const schemaIndexPath = path.join('src', 'schema', 'index.ts');
+        await formatAndLint([schemaPath, resolverPath, indexPath, schemaIndexPath]);
+
+        console.log(`\nCreated:\n- ${schemaPath}\n- ${resolverPath}\n- ${indexPath}`);
+        console.log(`Integrated into src/schema/index.ts (imports, typeDefs, resolvers).`);
+        console.log('\nOptional next step:\n- Run `pnpm codegen` to refresh TS types.');
+    } finally {
+        rl.close();
+    }
+}
+
+main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
         "verbatimModuleSyntax": true
     },
     "include": ["src/**/*.ts", "scripts/**/*.ts"],
-    "exclude": ["dist", "node_modules"]
+    "exclude": ["dist", "node_modules", "scripts"]
 }


### PR DESCRIPTION
This pull request introduces a new script to automate the creation and integration of new GraphQL types into the project, streamlining schema and resolver setup. Additionally, it adds a new npm script for running this generator. These changes are aimed at making it easier and less error-prone to add new types to the GraphQL schema.

**GraphQL type generation automation:**

* Added a new script `scripts/generate-type.ts` that interactively generates the schema, resolver, and index files for a new GraphQL type, integrates them into `src/schema/index.ts`, and ensures imports, typeDefs, and resolvers are alphabetized and properly formatted.
* The script also runs Prettier and ESLint on the generated files for code consistency.

**NPM scripts:**

* Added a new npm script `generate:type` in `package.json` to run the type generator with `pnpm generate:type`.