### PR TITLE
update script to scaffold a test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Use the generator to scaffold and integrate a new GraphQL type.
     - `src/schema/newType/newType.schema.ts` — Schema with type docstring and a placeholder field.
     - `src/schema/newType/newType.resolver.ts` — Parent type scaffold and placeholder resolver.
     - `src/schema/newType/index.ts` — Exports `<name>Defs` and `<name>Resolvers`.
+    - `src/schema/newType/__tests__/newType.resolver.test.ts` — Test scaffold for resolvers.
 
 3. Automatic integration
 

--- a/scripts/generate-type.ts
+++ b/scripts/generate-type.ts
@@ -71,6 +71,26 @@ export { ${resolversConst} } from './${camelName}.resolver.js';
 `;
 }
 
+function makeTestContent(typeName: string, camelName: string): string {
+    return `import { createTestClient, type TestGraphQLClient } from '../../../mocks/client.js';
+
+describe('${camelName}Resolvers', () => {
+    let client: TestGraphQLClient;
+
+    beforeEach(() => {
+        client = createTestClient();
+    });
+
+    describe('${typeName}.placeholder', () => {
+        it('resolves', async () => {
+            console.log('TODO: implement ${camelName}Resolvers tests', client);
+            return; // TODO
+        });
+    });
+});
+`;
+}
+
 async function ensureDir(dir: string) {
     try {
         await fs.mkdir(dir, { recursive: false });
@@ -221,23 +241,28 @@ async function main() {
         const schemaPath = path.join(baseDir, `${camelName}.schema.ts`);
         const resolverPath = path.join(baseDir, `${camelName}.resolver.ts`);
         const indexPath = path.join(baseDir, `index.ts`);
+        const testsDir = path.join(baseDir, '__tests__');
+        const testPath = path.join(testsDir, `${camelName}.resolver.test.ts`);
 
         await ensureDir(baseDir);
+        await ensureDir(testsDir);
 
         const schemaContent = makeSchemaContent(typeName, typeDescription, camelName);
         const resolverContent = makeResolverContent(typeName, camelName);
         const indexContent = makeIndexContent(camelName);
+        const testContent = makeTestContent(typeName, camelName);
 
         await fs.writeFile(schemaPath, schemaContent, 'utf8');
         await fs.writeFile(resolverPath, resolverContent, 'utf8');
         await fs.writeFile(indexPath, indexContent, 'utf8');
+        await fs.writeFile(testPath, testContent, 'utf8');
 
         await integrateIntoSchemaIndex(camelName);
 
         const schemaIndexPath = path.join('src', 'schema', 'index.ts');
-        await formatAndLint([schemaPath, resolverPath, indexPath, schemaIndexPath]);
+        await formatAndLint([schemaPath, resolverPath, indexPath, testPath, schemaIndexPath]);
 
-        console.log(`\nCreated:\n- ${schemaPath}\n- ${resolverPath}\n- ${indexPath}`);
+        console.log(`\nCreated:\n- ${schemaPath}\n- ${resolverPath}\n- ${indexPath}\n- ${testPath}`);
         console.log(`Integrated into src/schema/index.ts (imports, typeDefs, resolvers).`);
         console.log('\nOptional next step:\n- Run `pnpm codegen` to refresh TS types.');
     } finally {


### PR DESCRIPTION
This pull request enhances the GraphQL type generator by automatically scaffolding a test file for new resolvers. Now, whenever a new type is generated, a corresponding test file is created and integrated into the project structure, making it easier to maintain test coverage for newly added types.

### Generator enhancements

* Added automatic creation of a test scaffold file (`<type>.resolver.test.ts`) in a `__tests__` subdirectory when generating a new GraphQL type, ensuring every new resolver has a starting point for tests. [[1]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceR74-R93) [[2]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceR244-R265)
* Updated the generator's output and documentation to include the new test file, reflecting the improved workflow and file structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117) [[2]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceR244-R265)

### Developer experience improvements

* Ensured the new test file is included in formatting and linting steps, maintaining code quality and consistency.