### PR TITLE
update script to update codegen mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,19 @@ Unified GraphQL Yoga server merging multiple internal services into a single sch
 
 ## Workflow Notes
 
-- Husky enforces the `pre-commit` hook; lint-staged limits ESLint, Prettier, and type checking to staged files. Will also automatically run codegen if schema files are staged.
+- Husky enforces the `pre-commit` hook; lint-staged limits ESLint, Prettier, and type checking to staged files. Will
+  also automatically run codegen if schema files are staged.
 - Use Zod schemas to guard any new resolver inputs or configuration before exposing them to the merged graph.
 - Use Zod schemas to validate any external API responses before using them in resolvers.
 - Use dependency injection for services to make testing easier.
-- When fetching from external services, use HybridCache (src/utils/cache.ts) for caching the fetched values either in-memory or in a redis server.
+- When fetching from external services, use HybridCache (src/utils/cache.ts) for caching the fetched values either
+  in-memory or in a redis server.
 - Use mock factories for Yoga client, context, and env vars in src/mocks for tests
 
 #### Context & services (DI pattern)
 
-- Services are created once at server startup and injected into the GraphQL context via a factory. This avoids per-request instantiation while keeping testability.
+- Services are created once at server startup and injected into the GraphQL context via a factory. This avoids
+  per-request instantiation while keeping testability.
 - Runtime: `src/server.ts` builds singletons and passes them to the context factory:
 
     ```ts
@@ -93,7 +96,8 @@ Unified GraphQL Yoga server merging multiple internal services into a single sch
         });
     }
     ```
-- Tests: use `src/mocks/context.ts` (and `src/mocks/client.ts`) to get a fully‑formed `GraphQLContext` with mock `env` and real or mocked services; you can pass overrides per operation as needed.
+- Tests: use `src/mocks/context.ts` (and `src/mocks/client.ts`) to get a fully‑formed `GraphQLContext` with mock `env`
+  and real or mocked services; you can pass overrides per operation as needed.
 
 #### New schema types and resolvers
 
@@ -124,6 +128,9 @@ Use the generator to scaffold and integrate a new GraphQL type.
     - Insert `newTypeResolvers` in the Domain-specific resolvers block before `rootResolvers`.
     - Alphabetize the list of typeDefs (keeping `rootTypeDefs` first) and domain resolvers.
 
+    The generator also updates `codegen.ts` to add a mapper for the new type,
+    pointing to the Parent type in the new resolver file.
+
 4. Formatting and linting
 
     After scaffolding, it runs Prettier and ESLint on the new files and `src/schema/index.ts`.
@@ -131,12 +138,14 @@ Use the generator to scaffold and integrate a new GraphQL type.
 5. Next steps (manual)
     - Replace the placeholder field with real fields and ensure every type/field has a GraphQL docstring.
     - Flesh out the parent type and resolvers; implement any data fetching needed.
-    - If the new type should be reachable from `Query`, `Mutation`, or `Subscription`, update the root schema/resolvers accordingly.
+    - If the new type should be reachable from `Query`, `Mutation`, or `Subscription`, update the root schema/resolvers
+      accordingly.
     - When the schema is valid, run `pnpm codegen` to refresh generated TypeScript types.
 
 Notes
 
-- If a directory for the chosen type already exists, the generator will exit to avoid overwriting; remove the directory or choose another name.
+- If a directory for the chosen type already exists, the generator will exit to avoid overwriting;
+  remove the directory or choose another name.
 - The generator doesn’t execute codegen automatically because freshly scaffolded types may not be valid yet.
 - ESLint may report `@graphql-eslint/no-unreachable-types` for the new type until it is reachable from
   `Query`, `Mutation`, `Subscription`, or another type. This is expected. Even if ESLint exits with a non‑zero code, it


### PR DESCRIPTION
This pull request enhances the automation of schema type generation by improving how new GraphQL types are integrated into the codebase. The main focus is on making the process more robust and ensuring that codegen mappers and resolver arrays are updated and maintained in a consistent and error-resistant way.

Key improvements include:

**Automation of codegen mappers integration:**

* Added a new `updateCodegenMappers` function to automatically insert or update the relevant entry for the new type in the `mappers` object of `codegen.ts`. This function ensures correct formatting, alphabetical ordering, and handles both the presence and absence of an existing `mappers` block. [[1]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceR105-R181) [[2]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceR350-R357)

**Robustness for resolver integration:**

* Improved logic in `integrateIntoSchemaIndex` to support both possible syntaxes for the end of the `mergeResolvers` array in `src/schema/index.ts`, making the script more resilient to code style variations.

* Enhanced the resolver sorting function to handle both styles of resolver array suffixes, preserving any type assertions or comments after the resolver array. [[1]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceL183-R275) [[2]](diffhunk://#diff-1ec9b8f6b36e3bf6700b684292c8001b5f8bd5ab3b284f540b0a988d09a42bceL203-R292)

**Developer experience:**

* Updated the script output to inform the user when codegen mappers have been updated, and ensured that formatting and linting are applied to `codegen.ts` as well as the other affected files.