### PR TITLE
prepare gql server for npm export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "nchica-graph",
-    "version": "0.1.0",
-    "description": "Unified GraphQL Yoga server merging multiple internal services into a single schema and Render deployment.",
+    "version": "0.1.1",
+    "description": "Unified GraphQL Yoga server merging multiple internal services into a single schema.",
     "type": "module",
-    "main": "dist/server.js",
-    "types": "dist/server.d.ts",
+    "main": "dist/index.js",
+    "types": "dist/index.d.ts",
     "scripts": {
         "dev": "tsx watch src/server.ts",
         "start": "node dist/server.js",
@@ -14,6 +14,7 @@
         "format": "prettier --write .",
         "test": "vitest run --coverage",
         "prepare": "husky || true",
+        "prepack": "pnpm build",
         "codegen": "graphql-codegen --config codegen.ts",
         "generate:type": "tsx scripts/generate-type.ts"
     },
@@ -45,13 +46,25 @@
         "url": "https://github.com/nathanchica/nchica-graph/issues"
     },
     "homepage": "https://github.com/nathanchica/nchica-graph#readme",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js"
+        }
+    },
+    "files": [
+        "dist/**",
+        "README.md"
+    ],
+    "peerDependencies": {
+        "graphql": "^16.11.0"
+    },
     "dependencies": {
         "@graphql-tools/load-files": "^7.0.1",
         "@graphql-tools/merge": "^9.1.1",
         "@graphql-tools/schema": "^10.0.25",
         "dataloader": "^2.2.3",
         "dotenv": "^17.2.2",
-        "graphql": "^16.11.0",
         "graphql-scalars": "^1.24.2",
         "graphql-ws": "^6.0.6",
         "graphql-yoga": "^5.16.0",
@@ -63,6 +76,7 @@
         "zod": "^4.1.11"
     },
     "devDependencies": {
+        "graphql": "^16.11.0",
         "@eslint/js": "^9.36.0",
         "@graphql-codegen/cli": "^6.0.0",
         "@graphql-codegen/typescript": "^5.0.0",

--- a/src/http/graphqlServer.ts
+++ b/src/http/graphqlServer.ts
@@ -1,0 +1,146 @@
+import type { Server as HttpServer } from 'node:http';
+
+import { GraphQLError, execute as graphqlExecute, subscribe as graphqlSubscribe, type ExecutionArgs } from 'graphql';
+import { useServer } from 'graphql-ws/use/ws';
+import { createYoga, type YogaServerInstance } from 'graphql-yoga';
+import { WebSocketServer } from 'ws';
+
+import { createContextFactory, type GraphQLContext } from '../context.js';
+import { env } from '../env.js';
+import { schema } from '../schema/index.js';
+import { createACTRealtimeService } from '../services/actRealtime.js';
+import { createGTFSRealtimeService } from '../services/gtfsRealtime.js';
+import { getCachedOrFetch } from '../utils/cache.js';
+import { fetchWithUrlParams } from '../utils/fetch.js';
+
+const YOGA_EXECUTE_SYMBOL = Symbol('yoga.execute');
+const YOGA_SUBSCRIBE_SYMBOL = Symbol('yoga.subscribe');
+
+type YogaRootValue = {
+    [YOGA_EXECUTE_SYMBOL]: typeof graphqlExecute;
+    [YOGA_SUBSCRIBE_SYMBOL]: typeof graphqlSubscribe;
+};
+
+export interface CreateGraphQLServerOptions {
+    graphqlEndpoint?: string;
+    maskedErrors?: boolean;
+    graphiql?: boolean;
+}
+
+export interface RegisteredWsServer {
+    wsServer: WebSocketServer;
+    dispose: () => Promise<void>;
+}
+
+export interface GraphQLServer {
+    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+    yoga: YogaServerInstance<GraphQLContext, {}>;
+    graphqlEndpoint: string;
+    registerWs: (httpServer: HttpServer) => RegisteredWsServer;
+}
+
+export function createGraphQLServer(options?: CreateGraphQLServerOptions): GraphQLServer {
+    const graphqlEndpoint = options?.graphqlEndpoint ?? '/graphql';
+    const maskedErrors = options?.maskedErrors ?? env.NODE_ENV === 'production';
+    const graphiql = options?.graphiql ?? env.NODE_ENV !== 'production';
+
+    const services = {
+        actRealtime: createACTRealtimeService({
+            fetchWithUrlParams,
+            apiToken: env.AC_TRANSIT_TOKEN,
+            apiBaseUrl: env.ACT_REALTIME_API_BASE_URL,
+            cacheTtl: {
+                busStopProfiles: env.WHERE_IS_51B_CACHE_TTL_BUS_STOP_PROFILES,
+                predictions: env.WHERE_IS_51B_CACHE_TTL_PREDICTIONS,
+                vehiclePositions: env.WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS,
+            },
+            getCachedOrFetch,
+        }),
+        gtfsRealtime: createGTFSRealtimeService({
+            fetchWithUrlParams,
+            apiToken: env.AC_TRANSIT_TOKEN,
+            apiBaseUrl: env.GTFS_REALTIME_API_BASE_URL,
+            cacheTtl: {
+                vehiclePositions: env.WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS,
+                tripUpdates: env.WHERE_IS_51B_CACHE_TTL_PREDICTIONS,
+                serviceAlerts: env.WHERE_IS_51B_CACHE_TTL_SERVICE_ALERTS,
+            },
+            getCachedOrFetch,
+        }),
+    } as const;
+
+    const yoga = createYoga<GraphQLContext>({
+        schema,
+        context: createContextFactory(services),
+        maskedErrors,
+        graphiql,
+        graphqlEndpoint,
+    });
+
+    function registerWs(httpServer: HttpServer): RegisteredWsServer {
+        const wsServer = new WebSocketServer({
+            server: httpServer,
+            path: yoga.graphqlEndpoint,
+        });
+
+        const wsServerCleanup = useServer(
+            {
+                execute: async (args) => {
+                    const rootValue = args.rootValue as Partial<YogaRootValue> | undefined;
+                    const yogaExecute = rootValue?.[YOGA_EXECUTE_SYMBOL];
+                    return yogaExecute ? yogaExecute(args) : graphqlExecute(args);
+                },
+                subscribe: async (args) => {
+                    const rootValue = args.rootValue as Partial<YogaRootValue> | undefined;
+                    const yogaSubscribe = rootValue?.[YOGA_SUBSCRIBE_SYMBOL];
+                    return yogaSubscribe ? yogaSubscribe(args) : graphqlSubscribe(args);
+                },
+                onSubscribe: async (ctx, _id, payload) => {
+                    const { schema, execute, subscribe, contextFactory, parse, validate } = yoga.getEnveloped({
+                        ...ctx,
+                        req: ctx.extra.request,
+                        socket: ctx.extra.socket,
+                        params: payload,
+                    });
+
+                    if (!payload.query) {
+                        return [new GraphQLError('Missing subscription query')];
+                    }
+
+                    const document = typeof payload.query === 'string' ? parse(payload.query) : payload.query;
+                    const rootValue: YogaRootValue = {
+                        [YOGA_EXECUTE_SYMBOL]: execute,
+                        [YOGA_SUBSCRIBE_SYMBOL]: subscribe,
+                    };
+
+                    const executionArgs: ExecutionArgs = {
+                        schema,
+                        operationName: payload.operationName,
+                        document,
+                        variableValues: payload.variables,
+                        contextValue: await contextFactory(),
+                        rootValue,
+                    };
+
+                    const errors = validate(schema, executionArgs.document);
+                    if (errors.length > 0) {
+                        return errors;
+                    }
+
+                    return executionArgs;
+                },
+            },
+            wsServer
+        );
+
+        const dispose = async () => {
+            await wsServerCleanup.dispose();
+            wsServer.clients.forEach((socket) => socket.close(1001, 'Server shutting down'));
+            wsServer.close();
+        };
+
+        return { wsServer, dispose };
+    }
+
+    return { yoga, graphqlEndpoint: yoga.graphqlEndpoint, registerWs };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { createGraphQLServer } from './http/graphqlServer.js';
+export type { GraphQLContext } from './context.js';

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,120 +1,20 @@
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
-import { GraphQLError, execute as graphqlExecute, subscribe as graphqlSubscribe, type ExecutionArgs } from 'graphql';
-import { useServer } from 'graphql-ws/use/ws';
-import { createYoga } from 'graphql-yoga';
-import { WebSocketServer } from 'ws';
-
-import { createContextFactory, type GraphQLContext } from './context.js';
 import { env } from './env.js';
-import { schema } from './schema/index.js';
-import { createACTRealtimeService } from './services/actRealtime.js';
-import { createGTFSRealtimeService } from './services/gtfsRealtime.js';
-import { getCachedOrFetch } from './utils/cache.js';
-import { fetchWithUrlParams } from './utils/fetch.js';
+import { createGraphQLServer } from './http/graphqlServer.js';
 
-const YOGA_EXECUTE_SYMBOL = Symbol('yoga.execute');
-const YOGA_SUBSCRIBE_SYMBOL = Symbol('yoga.subscribe');
-
-type YogaRootValue = {
-    [YOGA_EXECUTE_SYMBOL]: typeof graphqlExecute;
-    [YOGA_SUBSCRIBE_SYMBOL]: typeof graphqlSubscribe;
-};
-
-const services = {
-    actRealtime: createACTRealtimeService({
-        fetchWithUrlParams,
-        apiToken: env.AC_TRANSIT_TOKEN,
-        apiBaseUrl: env.ACT_REALTIME_API_BASE_URL,
-        cacheTtl: {
-            busStopProfiles: env.WHERE_IS_51B_CACHE_TTL_BUS_STOP_PROFILES,
-            predictions: env.WHERE_IS_51B_CACHE_TTL_PREDICTIONS,
-            vehiclePositions: env.WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS,
-        },
-        getCachedOrFetch,
-    }),
-    gtfsRealtime: createGTFSRealtimeService({
-        fetchWithUrlParams,
-        apiToken: env.AC_TRANSIT_TOKEN,
-        apiBaseUrl: env.GTFS_REALTIME_API_BASE_URL,
-        cacheTtl: {
-            vehiclePositions: env.WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS,
-            tripUpdates: env.WHERE_IS_51B_CACHE_TTL_PREDICTIONS,
-            serviceAlerts: env.WHERE_IS_51B_CACHE_TTL_SERVICE_ALERTS,
-        },
-        getCachedOrFetch,
-    }),
-};
-
-const yoga = createYoga<GraphQLContext>({
-    schema,
-    context: createContextFactory(services),
+const { yoga, registerWs } = createGraphQLServer({
+    graphqlEndpoint: '/graphql',
     maskedErrors: env.NODE_ENV === 'production',
     graphiql: env.NODE_ENV !== 'production',
 });
 
 const httpServer = createServer(yoga);
-
-const wsServer = new WebSocketServer({
-    server: httpServer,
-    path: yoga.graphqlEndpoint,
-});
-
-const wsServerCleanup = useServer(
-    {
-        execute: async (args) => {
-            const rootValue = args.rootValue as Partial<YogaRootValue> | undefined;
-            const yogaExecute = rootValue?.[YOGA_EXECUTE_SYMBOL];
-            return yogaExecute ? yogaExecute(args) : graphqlExecute(args);
-        },
-        subscribe: async (args) => {
-            const rootValue = args.rootValue as Partial<YogaRootValue> | undefined;
-            const yogaSubscribe = rootValue?.[YOGA_SUBSCRIBE_SYMBOL];
-            return yogaSubscribe ? yogaSubscribe(args) : graphqlSubscribe(args);
-        },
-        onSubscribe: async (ctx, _id, payload) => {
-            const { schema, execute, subscribe, contextFactory, parse, validate } = yoga.getEnveloped({
-                ...ctx,
-                req: ctx.extra.request,
-                socket: ctx.extra.socket,
-                params: payload,
-            });
-
-            if (!payload.query) {
-                return [new GraphQLError('Missing subscription query')];
-            }
-
-            const document = typeof payload.query === 'string' ? parse(payload.query) : payload.query;
-            const rootValue: YogaRootValue = {
-                [YOGA_EXECUTE_SYMBOL]: execute,
-                [YOGA_SUBSCRIBE_SYMBOL]: subscribe,
-            };
-
-            const executionArgs: ExecutionArgs = {
-                schema,
-                operationName: payload.operationName,
-                document,
-                variableValues: payload.variables,
-                contextValue: await contextFactory(),
-                rootValue,
-            };
-
-            const errors = validate(schema, executionArgs.document);
-            if (errors.length > 0) {
-                return errors;
-            }
-
-            return executionArgs;
-        },
-    },
-    wsServer
-);
+const { dispose } = registerWs(httpServer);
 
 const shutdown = async () => {
-    await wsServerCleanup.dispose();
-    wsServer.clients.forEach((socket) => socket.close(1001, 'Server shutting down'));
-    wsServer.close();
+    await dispose();
     httpServer.close();
 };
 


### PR DESCRIPTION
This pull request introduces a major refactor to support using the GraphQL server as a reusable library, making it easier to integrate into other Node.js applications (such as Express gateways), and improves packaging for distribution on npm. The server instantiation, context, and WebSocket subscription logic are now encapsulated in a new `createGraphQLServer` factory, and the package is set up for proper library consumption with updated exports and peer dependencies.

**Library integration and server instantiation:**

- Added `createGraphQLServer` in `src/http/graphqlServer.ts`, which encapsulates Yoga server creation, context wiring, and WebSocket subscription support. This enables mounting the GraphQL API into any Node.js HTTP server and cleanly registering WebSocket subscriptions, with lifecycle management for shutdown.
- Updated the main server entry (`src/server.ts`) to use `createGraphQLServer`, greatly simplifying the application code and aligning both standalone and library usage patterns.

**Package distribution and exports:**

- Updated `package.json` to:
  - Set the entry point to `dist/index.js` and export types and runtime via the `exports` field.
  - Move `graphql` to a peer dependency (required for consumers).
  - Add a `prepack` script to ensure the build runs before publishing.
  - Include only necessary files in the published package. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R49-L54) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R79)

**Documentation improvements:**

- Expanded `README.md` with detailed instructions and code samples for using the package as a library in gateway/server setups, including Express and WebSocket integration.
- Clarified the context and service instantiation pattern for both standalone and library modes, and documented the publishing process and peer dependency requirements. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R108) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R173-R182)

**Exports for consumers:**

- Added top-level exports for `createGraphQLServer` and `GraphQLContext` in `src/index.ts` so consumers can easily import these APIs.

These changes make the GraphQL server modular, easier to integrate, and ready for consumption as an npm package.