### PR TITLE
update env var handling to differentiate library use and standalone use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.1] - 2025-09-27
+
+Added
+
+- Library factory `createGraphQLServer` exposing:
+    - `yoga` (GraphQL Yoga request handler)
+    - `registerWs(httpServer)` to attach `graphql-ws` subscriptions on the same server and path
+- Public entry `src/index.ts` exporting `createGraphQLServer` and `GraphQLContext`.
+- README section on Gateway Integration and Environment Variables.
+
+Changed
+
+- Standalone server (`src/server.ts`) now uses `createGraphQLServer` for parity with library usage.
+- Environment handling: removed `dotenv` side-effect from `src/env.ts`; standalone server imports `dotenv/config` instead.
+- Lint/type safety: replaced empty object generic usage with a precise Yoga return type to satisfy `@typescript-eslint/no-empty-object-type`.
+
+Packaging
+
+- `package.json`:
+    - `main`/`types` point to `dist/index.*`.
+    - Added `exports` for ESM consumers.
+    - Added `files` whitelist (`dist/**`, `README.md`).
+    - Added `prepack` script to build on publish.
+    - Moved `graphql` to `peerDependencies` and kept it in `devDependencies` for local development.
+
+## [0.1.0] - 2024-09-22
+
+Initial release of GraphQL Yoga server with schema composition, caching utilities, and tests.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,37 @@ Notes
 - Socket.IO (if used) can share the same `httpServer` (default path `/socket.io`) without conflicting with `/graphql`.
 - Keep Yoga mounted at `/graphql` and register WS with the same server so subscriptions work out-of-the-box.
 
+## Environment Variables
+
+Library usage (in a gateway)
+
+- This package reads environment from `process.env` only; it does not call dotenv.
+- On Render (or any host), configure env vars in the service; they are available to this library at runtime.
+
+Standalone dev (this repo)
+
+- The standalone server (`src/server.ts`) imports `dotenv/config` to load `.env` for local development.
+
+Required
+
+- `AC_TRANSIT_TOKEN` – API token for AC Transit services.
+
+Optional (defaults exist)
+
+- `NODE_ENV` (default: `development`)
+- `HOST` (default: `localhost`)
+- `PORT` (default: `4000`)
+- `ENABLE_CACHE` (default: `true`)
+- `REDIS_URL` (if unset, falls back to in‑memory cache)
+- `ACT_REALTIME_API_BASE_URL`, `GTFS_REALTIME_API_BASE_URL`
+- `AC_TRANSIT_POLLING_INTERVAL`, `AC_TRANSIT_ALERTS_POLLING_INTERVAL`
+- `WHERE_IS_51B_CACHE_TTL_VEHICLE_POSITIONS`, `WHERE_IS_51B_CACHE_TTL_PREDICTIONS`, `WHERE_IS_51B_CACHE_TTL_SERVICE_ALERTS`, `WHERE_IS_51B_CACHE_TTL_BUS_STOP_PROFILES`
+
+Notes
+
+- Env validation occurs at module import via Zod. Missing required vars will throw early, which is intended.
+- In gateways, ensure env is set before the app starts (Render does this automatically).
+
 ## Workflow Notes
 
 - Husky enforces the `pre-commit` hook; lint-staged limits ESLint, Prettier, and type checking to staged files. Will

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nchica-graph",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Unified GraphQL Yoga server merging multiple internal services into a single schema.",
     "type": "module",
     "main": "dist/index.js",

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,9 +1,4 @@
-import * as dotenv from 'dotenv';
 import { z } from 'zod';
-
-dotenv.config({
-    quiet: true,
-});
 
 const envSchema = z.object({
     NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),

--- a/src/http/graphqlServer.ts
+++ b/src/http/graphqlServer.ts
@@ -2,7 +2,7 @@ import type { Server as HttpServer } from 'node:http';
 
 import { GraphQLError, execute as graphqlExecute, subscribe as graphqlSubscribe, type ExecutionArgs } from 'graphql';
 import { useServer } from 'graphql-ws/use/ws';
-import { createYoga, type YogaServerInstance } from 'graphql-yoga';
+import { createYoga } from 'graphql-yoga';
 import { WebSocketServer } from 'ws';
 
 import { createContextFactory, type GraphQLContext } from '../context.js';
@@ -33,8 +33,7 @@ export interface RegisteredWsServer {
 }
 
 export interface GraphQLServer {
-    // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-    yoga: YogaServerInstance<GraphQLContext, {}>;
+    yoga: ReturnType<typeof createYoga<GraphQLContext>>;
     graphqlEndpoint: string;
     registerWs: (httpServer: HttpServer) => RegisteredWsServer;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
                 'graphql.config.js',
                 'src/**/__mocks__/**',
                 'scripts/**',
+                'src/http/**',
             ],
         },
         setupFiles: ['./src/testSetup.ts'],


### PR DESCRIPTION
This pull request introduces several improvements to environment variable handling, developer documentation, and type safety, along with some packaging and versioning updates. The main focus is to clarify how environment variables are managed for both library and standalone server usage, improve type correctness, and ensure a smoother developer experience.

**Environment variable handling and documentation:**

* Added a new section in the `README.md` explaining environment variable usage for both library (gateway) and standalone server contexts, including required and optional variables and validation behavior.
* Updated the environment variable loading strategy: removed the `dotenv` side-effect from `src/env.ts` so that the library only reads from `process.env`, while the standalone server (`src/server.ts`) now imports `dotenv/config` directly for local development. [[1]](diffhunk://#diff-00ee6a506727e42b3fb03361b8216c805ede24dc3985d237de852a73bda59f30L1-L7) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R1)

**Type safety and API surface:**

* Changed the `GraphQLServer` interface in `src/http/graphqlServer.ts` to use a precise Yoga return type instead of an empty object generic, addressing type safety and linting concerns. [[1]](diffhunk://#diff-95e052db937c2b0d88d549cf76cce72506138bd05c0d32d7dc931d003779e344L5-R5) [[2]](diffhunk://#diff-95e052db937c2b0d88d549cf76cce72506138bd05c0d32d7dc931d003779e344L36-R36)

**Documentation and changelog:**

* Added a `CHANGELOG.md` file summarizing notable changes, including the new `createGraphQLServer` factory, environment handling, and packaging updates.

**Packaging and versioning:**

* Bumped the package version to `0.1.2` in `package.json`.

**Test configuration:**

* Updated the `vitest.config.ts` to include `src/http/**` in the coverage ignore list.