### PR TITLE
bus predictions type and resolvers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,7 +3,12 @@ import type { YogaInitialContext } from 'graphql-yoga';
 import type { Env } from './env.js';
 import { env } from './env.js';
 import { createBusPositionsByRouteLoader, type BusPositionsByRouteLoader } from './loaders/busPosition.js';
-import { createBusStopByCodeLoader, type BusStopByCodeLoader } from './loaders/busStop.js';
+import {
+    createBusStopByCodeLoader,
+    type BusStopByCodeLoader,
+    createBusStopPredictionsLoader,
+    type BusStopPredictionsLoader,
+} from './loaders/busStop.js';
 import type { ACTRealtimeServiceType } from './services/actRealtime.js';
 import type { GTFSRealtimeServiceType } from './services/gtfsRealtime.js';
 
@@ -14,6 +19,7 @@ export type Services = {
 export type Loaders = {
     busStop: {
         byCode: BusStopByCodeLoader;
+        predictions: BusStopPredictionsLoader;
     };
     bus: {
         byRoute: BusPositionsByRouteLoader;
@@ -30,6 +36,7 @@ export function createContextFactory(services: Services) {
         const loaders: Loaders = {
             busStop: {
                 byCode: createBusStopByCodeLoader(services.actRealtime),
+                predictions: createBusStopPredictionsLoader(services.actRealtime),
             },
             bus: {
                 byRoute: createBusPositionsByRouteLoader(services.actRealtime),

--- a/src/formatters/__tests__/busStopPrediction.test.ts
+++ b/src/formatters/__tests__/busStopPrediction.test.ts
@@ -55,18 +55,14 @@ describe('createBusStopPredictionsFromActRealtime', () => {
         expect(result[0].vehicleId).toBe('V-OUT-2');
         expect(result[0].tripId).toBe('TRIP-OUT-2');
         expect(result[0].arrivalTime.toISOString()).toBe('2024-07-01T19:05:00.000Z');
-        expect(result[0].departureTime.toISOString()).toBe('2024-07-01T19:05:00.000Z');
         expect(result[0].minutesAway).toBe(0); // clamped from -2
         expect(result[0].isOutbound).toBe(true);
-        expect(result[0].distanceToStopFeet).toBeNull(); // Infinity -> null
 
         expect(result[1].vehicleId).toBe('V-OUT-1');
         expect(result[1].tripId).toBe('TRIP-OUT-1');
         expect(result[1].arrivalTime.toISOString()).toBe('2024-07-01T19:10:00.000Z');
-        expect(result[1].departureTime.toISOString()).toBe('2024-07-01T19:10:00.000Z');
         expect(result[1].minutesAway).toBe(5);
         expect(result[1].isOutbound).toBe(true);
-        expect(result[1].distanceToStopFeet).toBe(123);
     });
 
     it('treats "Due" prdctdn as 0 for outbound predictions', () => {
@@ -85,7 +81,6 @@ describe('createBusStopPredictionsFromActRealtime', () => {
         expect(result[0].tripId).toBe('TRIP-DUE');
         expect(result[0].minutesAway).toBe(0);
         expect(result[0].arrivalTime.toISOString()).toBe('2024-07-01T19:00:00.000Z');
-        expect(result[0].departureTime.toISOString()).toBe('2024-07-01T19:00:00.000Z');
         expect(result[0].isOutbound).toBe(true);
     });
 
@@ -176,17 +171,13 @@ describe('createBusStopPredictionsFromGtfsFeed', () => {
         expect(outbound[0].tripId).toBe('TRIP-1');
         expect(outbound[0].minutesAway).toBe(0); // clamped from -3
         expect(outbound[0].arrivalTime.toISOString()).toBe('2024-12-31T23:57:00.000Z');
-        expect(outbound[0].departureTime.toISOString()).toBe('2024-12-31T23:57:00.000Z');
         expect(outbound[0].isOutbound).toBe(true);
-        expect(outbound[0].distanceToStopFeet).toBeNull();
 
         expect(outbound[1].arrivalTime.toISOString()).toBe('2025-01-01T00:05:00.000Z');
-        expect(outbound[1].departureTime.toISOString()).toBe('2025-01-01T00:06:00.000Z');
         expect(outbound[1].minutesAway).toBe(5);
         expect(outbound[1].isOutbound).toBe(true);
 
         expect(outbound[2].arrivalTime.toISOString()).toBe('2025-01-01T00:20:00.000Z'); // arrival fallback to departure
-        expect(outbound[2].departureTime.toISOString()).toBe('2025-01-01T00:20:00.000Z');
         expect(outbound[2].minutesAway).toBe(20);
         expect(outbound[2].isOutbound).toBe(true);
 

--- a/src/formatters/busStopPrediction.ts
+++ b/src/formatters/busStopPrediction.ts
@@ -7,10 +7,8 @@ export interface BusStopPrediction {
     vehicleId: string;
     tripId: string;
     arrivalTime: Date;
-    departureTime: Date;
     minutesAway: number;
     isOutbound: boolean;
-    distanceToStopFeet: number | null;
 }
 
 function parseMinutesAway(value: string): number {
@@ -54,10 +52,8 @@ export function createBusStopPredictionsFromActRealtime(
                 vehicleId: prediction.vid,
                 tripId: prediction.tatripid,
                 arrivalTime,
-                departureTime: arrivalTime,
                 minutesAway: formatMinutesAway(minutesAway),
                 isOutbound: isOutboundDirection(prediction.rtdir),
-                distanceToStopFeet: Number.isFinite(prediction.dstp) ? prediction.dstp : null,
             };
         })
         .sort((a, b) => a.arrivalTime.getTime() - b.arrivalTime.getTime());
@@ -94,7 +90,6 @@ export function createBusStopPredictionsFromGtfsFeed(
                     const departureUnixTime = stopTimeUpdate.departure?.time;
 
                     const arrivalTime = new Date(Number(arrivalUnixTime || departureUnixTime) * 1000);
-                    const departureTime = new Date(Number(departureUnixTime || arrivalUnixTime) * 1000);
 
                     const now = new Date();
                     const minutesAway = Math.round((arrivalTime.getTime() - now.getTime()) / 60000);
@@ -104,9 +99,7 @@ export function createBusStopPredictionsFromGtfsFeed(
                         vehicleId,
                         isOutbound: tripIsOutbound,
                         arrivalTime,
-                        departureTime,
                         minutesAway: formatMinutesAway(minutesAway),
-                        distanceToStopFeet: null, // GTFS-RT doesn't provide distance data
                     };
                 });
         });

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -509,3 +509,32 @@ export type GetBusStopProfileLongitudeQuery = {
         busStop: { __typename?: 'AcTransitBusStop'; position: { __typename?: 'Position'; longitude: number } } | null;
     } | null;
 };
+
+export type BusStopPredictionsSubscriptionSubscriptionVariables = Exact<{
+    routeId: Scalars['String']['input'];
+    stopCode: Scalars['String']['input'];
+    direction: BusDirection;
+}>;
+
+export type BusStopPredictionsSubscriptionSubscription = {
+    __typename?: 'Subscription';
+    busStopPredictions: Array<{
+        __typename?: 'BusStopPrediction';
+        vehicleId: string;
+        tripId: string;
+        arrivalTime: Date;
+        minutesAway: number;
+        isOutbound: boolean;
+    }>;
+};
+
+export type BusStopPredictionsSubscriptionVariables = Exact<{
+    routeId: Scalars['String']['input'];
+    stopCode: Scalars['String']['input'];
+    direction: BusDirection;
+}>;
+
+export type BusStopPredictionsSubscription = {
+    __typename?: 'Subscription';
+    busStopPredictions: Array<{ __typename?: 'BusStopPrediction'; vehicleId: string }>;
+};

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -70,6 +70,14 @@ export type Bus = {
     vehicleId: Scalars['String']['output'];
 };
 
+/** Enum for bus direction */
+export enum BusDirection {
+    /** Inbound (going towards downtown) */
+    Inbound = 'INBOUND',
+    /** Outbound (going away from downtown) */
+    Outbound = 'OUTBOUND',
+}
+
 /** Represents a bus stop in any transit system */
 export type BusStop = {
     /** GTFS stop identifier (sequential ID used in GTFS feeds, e.g., "1234") */
@@ -78,6 +86,21 @@ export type BusStop = {
     name: Scalars['String']['output'];
     /** Geographic position of the stop */
     position: Position;
+};
+
+/** Represents a predicted bus arrival at a stop */
+export type BusStopPrediction = {
+    __typename?: 'BusStopPrediction';
+    /** Predicted arrival time */
+    arrivalTime: Scalars['DateTime']['output'];
+    /** True if bus is heading outbound (away from downtown) */
+    isOutbound: Scalars['Boolean']['output'];
+    /** Number of minutes until arrival */
+    minutesAway: Scalars['Int']['output'];
+    /** GTFS trip identifier */
+    tripId: Scalars['String']['output'];
+    /** Vehicle identifier for the approaching bus */
+    vehicleId: Scalars['String']['output'];
 };
 
 /** Represents a geographic position and direction (if movable) */
@@ -114,10 +137,19 @@ export type Subscription = {
     __typename?: 'Subscription';
     /** Subscribe to current system date and time of AC Transit system */
     acTransitSystemTime: Scalars['DateTime']['output'];
+    /** Subscribe to real-time arrival predictions for a specific bus stop */
+    busStopPredictions: Array<BusStopPrediction>;
     /** List of all buses in the AC Transit system */
     busesByRoute: Array<Bus>;
     /** Heartbeat subscription that emits current timestamp every second */
     heartbeat: Scalars['DateTime']['output'];
+};
+
+/** Root subscription type for real-time updates */
+export type SubscriptionBusStopPredictionsArgs = {
+    direction: BusDirection;
+    routeId: Scalars['String']['input'];
+    stopCode: Scalars['String']['input'];
 };
 
 /** Root subscription type for real-time updates */
@@ -229,9 +261,12 @@ export type ResolversTypes = {
     AcTransitBusStop: ResolverTypeWrapper<AcTransitBusStopParent>;
     Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
     Bus: ResolverTypeWrapper<BusParent>;
+    BusDirection: BusDirection;
     BusStop: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['BusStop']>;
+    BusStopPrediction: ResolverTypeWrapper<BusStopPrediction>;
     DateTime: ResolverTypeWrapper<Scalars['DateTime']['output']>;
     Float: ResolverTypeWrapper<Scalars['Float']['output']>;
+    Int: ResolverTypeWrapper<Scalars['Int']['output']>;
     Position: ResolverTypeWrapper<Position>;
     Query: ResolverTypeWrapper<Record<PropertyKey, never>>;
     String: ResolverTypeWrapper<Scalars['String']['output']>;
@@ -246,8 +281,10 @@ export type ResolversParentTypes = {
     Boolean: Scalars['Boolean']['output'];
     Bus: BusParent;
     BusStop: ResolversInterfaceTypes<ResolversParentTypes>['BusStop'];
+    BusStopPrediction: BusStopPrediction;
     DateTime: Scalars['DateTime']['output'];
     Float: Scalars['Float']['output'];
+    Int: Scalars['Int']['output'];
     Position: Position;
     Query: Record<PropertyKey, never>;
     String: Scalars['String']['output'];
@@ -302,6 +339,17 @@ export type BusStopResolvers<
     __resolveType: TypeResolveFn<'AcTransitBusStop', ParentType, ContextType>;
 };
 
+export type BusStopPredictionResolvers<
+    ContextType = GraphQLContext,
+    ParentType extends ResolversParentTypes['BusStopPrediction'] = ResolversParentTypes['BusStopPrediction'],
+> = {
+    arrivalTime?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
+    isOutbound?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+    minutesAway?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+    tripId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+    vehicleId?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+};
+
 export interface DateTimeScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DateTime'], any> {
     name: 'DateTime';
 }
@@ -340,6 +388,13 @@ export type SubscriptionResolvers<
         ParentType,
         ContextType
     >;
+    busStopPredictions?: SubscriptionResolver<
+        Array<ResolversTypes['BusStopPrediction']>,
+        'busStopPredictions',
+        ParentType,
+        ContextType,
+        RequireFields<SubscriptionBusStopPredictionsArgs, 'direction' | 'routeId' | 'stopCode'>
+    >;
     busesByRoute?: SubscriptionResolver<
         Array<ResolversTypes['Bus']>,
         'busesByRoute',
@@ -362,6 +417,7 @@ export type Resolvers<ContextType = GraphQLContext> = {
     AcTransitBusStop?: AcTransitBusStopResolvers<ContextType>;
     Bus?: BusResolvers<ContextType>;
     BusStop?: BusStopResolvers<ContextType>;
+    BusStopPrediction?: BusStopPredictionResolvers<ContextType>;
     DateTime?: GraphQLScalarType;
     Position?: PositionResolvers<ContextType>;
     Query?: QueryResolvers<ContextType>;

--- a/src/loaders/__tests__/busPosition.test.ts
+++ b/src/loaders/__tests__/busPosition.test.ts
@@ -1,0 +1,58 @@
+import { vi } from 'vitest';
+
+import { createBusPositionsFromActRealtime } from '../../formatters/busPosition.js';
+import { createMockACTRealtimeService } from '../../services/__mocks__/actRealtime.js';
+import { createMockBusPositionRaw } from '../../services/__mocks__/actRealtimeResponses.js';
+import { createBusPositionsByRouteLoader } from '../busPosition.js';
+
+describe('createBusPositionsByRouteLoader', () => {
+    it('returns formatted positions for a route', async () => {
+        const routeId = '51B';
+        const raw = [
+            createMockBusPositionRaw({ vid: 'V-1', rt: routeId, lat: '37.1', lon: '-122.1', hdg: '45', spd: 12 }),
+            createMockBusPositionRaw({ vid: 'V-2', rt: routeId, lat: '37.2', lon: '-122.2', hdg: '90', spd: 18 }),
+        ];
+
+        const fetchBusPositions = vi.fn().mockResolvedValue(raw);
+        const actRealtime = createMockACTRealtimeService({ fetchBusPositions });
+
+        const loader = createBusPositionsByRouteLoader(actRealtime);
+        const result = await loader.load(routeId);
+
+        expect(result).toEqual(createBusPositionsFromActRealtime(raw));
+        expect(fetchBusPositions).toHaveBeenCalledTimes(1);
+        expect(fetchBusPositions).toHaveBeenCalledWith(routeId);
+    });
+
+    it('returns empty array when upstream returns empty', async () => {
+        const routeId = '6';
+        const fetchBusPositions = vi.fn().mockResolvedValue([]);
+        const actRealtime = createMockACTRealtimeService({ fetchBusPositions });
+
+        const loader = createBusPositionsByRouteLoader(actRealtime);
+        const result = await loader.load(routeId);
+
+        expect(result).toEqual([]);
+        expect(fetchBusPositions).toHaveBeenCalledTimes(1);
+        expect(fetchBusPositions).toHaveBeenCalledWith(routeId);
+    });
+
+    it('handles multiple routes in a single batch', async () => {
+        const a = '1';
+        const b = '2';
+        const rawA = [createMockBusPositionRaw({ vid: 'A-1', rt: a, lat: '37.0', lon: '-122.0' })];
+        const rawB = [createMockBusPositionRaw({ vid: 'B-1', rt: b, lat: '38.0', lon: '-123.0' })];
+
+        const fetchBusPositions = vi.fn().mockResolvedValueOnce(rawA).mockResolvedValueOnce(rawB);
+        const actRealtime = createMockACTRealtimeService({ fetchBusPositions });
+
+        const loader = createBusPositionsByRouteLoader(actRealtime);
+        const [resA, resB] = await loader.loadMany([a, b]);
+
+        expect(resA).toEqual(createBusPositionsFromActRealtime(rawA));
+        expect(resB).toEqual(createBusPositionsFromActRealtime(rawB));
+        expect(fetchBusPositions).toHaveBeenCalledTimes(2);
+        expect(fetchBusPositions).toHaveBeenNthCalledWith(1, a);
+        expect(fetchBusPositions).toHaveBeenNthCalledWith(2, b);
+    });
+});

--- a/src/loaders/__tests__/busStop.test.ts
+++ b/src/loaders/__tests__/busStop.test.ts
@@ -1,0 +1,74 @@
+import { createBusStopProfile } from '../../formatters/busStop.js';
+import { createMockACTRealtimeService } from '../../services/__mocks__/actRealtime.js';
+import { createMockBusStopProfileRaw } from '../../services/__mocks__/actRealtimeResponses.js';
+import { createBusStopByCodeLoader, createBusStopPredictionsLoader } from '../busStop.js';
+
+describe('busStop loaders', () => {
+    describe('createBusStopPredictionsLoader', () => {
+        it('falls back to empty map/array when upstream returns undefined (covers defaults)', async () => {
+            const routeId = '51B';
+            const stopCode = '50373';
+
+            const fetchBusStopPredictions = vi.fn().mockResolvedValue(undefined);
+            const actRealtime = createMockACTRealtimeService({ fetchBusStopPredictions });
+
+            const loader = createBusStopPredictionsLoader(actRealtime);
+
+            const result = await loader.load({ routeId, stopCode, direction: 'OUTBOUND' });
+
+            // Should gracefully default to [] when no entry for route/stop exists
+            expect(result).toEqual([]);
+
+            // Ensure upstream was called with grouped params
+            expect(fetchBusStopPredictions).toHaveBeenCalledTimes(1);
+            expect(fetchBusStopPredictions).toHaveBeenCalledWith([stopCode], routeId);
+        });
+    });
+
+    describe('createBusStopByCodeLoader', () => {
+        it('returns formatted profile for existing code', async () => {
+            const code = '55555';
+            const raw = createMockBusStopProfileRaw({ stpid: code, geoid: 'GTFS_55555', stpnm: 'Test Stop' });
+
+            const fetchBusStopProfiles = vi.fn().mockResolvedValue({ [code]: raw });
+            const actRealtime = createMockACTRealtimeService({ fetchBusStopProfiles });
+
+            const loader = createBusStopByCodeLoader(actRealtime);
+            const result = await loader.load(code);
+
+            expect(result).toEqual(createBusStopProfile(raw));
+            expect(fetchBusStopProfiles).toHaveBeenCalledTimes(1);
+            expect(fetchBusStopProfiles).toHaveBeenCalledWith([code]);
+        });
+
+        it('returns null when profile is missing', async () => {
+            const code = '99999';
+            const fetchBusStopProfiles = vi.fn().mockResolvedValue({});
+            const actRealtime = createMockACTRealtimeService({ fetchBusStopProfiles });
+
+            const loader = createBusStopByCodeLoader(actRealtime);
+            const result = await loader.load(code);
+
+            expect(result).toBeNull();
+            expect(fetchBusStopProfiles).toHaveBeenCalledTimes(1);
+            expect(fetchBusStopProfiles).toHaveBeenCalledWith([code]);
+        });
+
+        it('batches multiple codes in single fetch call via loadMany', async () => {
+            const codeA = '11111';
+            const codeB = '22222';
+            const rawA = createMockBusStopProfileRaw({ stpid: codeA, geoid: 'GTFS_A', stpnm: 'Stop A' });
+            const rawB = createMockBusStopProfileRaw({ stpid: codeB, geoid: 'GTFS_B', stpnm: 'Stop B' });
+
+            const fetchBusStopProfiles = vi.fn().mockResolvedValue({ [codeA]: rawA, [codeB]: rawB });
+            const actRealtime = createMockACTRealtimeService({ fetchBusStopProfiles });
+
+            const loader = createBusStopByCodeLoader(actRealtime);
+            const results = await loader.loadMany([codeA, codeB]);
+
+            expect(results).toEqual([createBusStopProfile(rawA), createBusStopProfile(rawB)]);
+            expect(fetchBusStopProfiles).toHaveBeenCalledTimes(1);
+            expect(fetchBusStopProfiles).toHaveBeenCalledWith([codeA, codeB]);
+        });
+    });
+});

--- a/src/loaders/busStop.ts
+++ b/src/loaders/busStop.ts
@@ -1,7 +1,9 @@
 import DataLoader from 'dataloader';
 
 import { createBusStopProfile, type BusStopProfile } from '../formatters/busStop.js';
+import { createBusStopPredictionsFromActRealtime, type BusStopPrediction } from '../formatters/busStopPrediction.js';
 import type { ACTRealtimeServiceType } from '../services/actRealtime.js';
+import type { BusStopPredictionRaw } from '../services/actRealtime.schemas.js';
 
 export type BusStopByCodeLoader = DataLoader<string, BusStopProfile | null>;
 
@@ -16,5 +18,50 @@ export function createBusStopByCodeLoader(actRealtime: ACTRealtimeServiceType): 
             });
         },
         { cacheKeyFn: (key) => key }
+    );
+}
+
+export type BusStopPredictionsKey = {
+    routeId: string;
+    stopCode: string;
+    direction: 'INBOUND' | 'OUTBOUND';
+};
+
+export type BusStopPredictionsLoader = DataLoader<BusStopPredictionsKey, Array<BusStopPrediction>, string>;
+
+export function createBusStopPredictionsLoader(actRealtime: ACTRealtimeServiceType): BusStopPredictionsLoader {
+    return new DataLoader<BusStopPredictionsKey, Array<BusStopPrediction>, string>(
+        async (keys) => {
+            // Group by routeId to pass through to the upstream API for filtering
+            const byRoute: Record<string, Set<string>> = {};
+            for (const { routeId, stopCode } of keys) {
+                const routeKey = routeId ?? 'all';
+                byRoute[routeKey] ??= new Set<string>();
+                byRoute[routeKey].add(stopCode);
+            }
+
+            const routeKeys = Object.keys(byRoute);
+            const resultsByRoute: Record<string, Record<string, Array<BusStopPredictionRaw>>> = {};
+
+            await Promise.all(
+                routeKeys.map(async (routeKey) => {
+                    const stopCodes = Array.from(byRoute[routeKey]);
+                    const routeParam = routeKey === 'all' || routeKey === '' ? undefined : routeKey;
+                    const map = await actRealtime.fetchBusStopPredictions(stopCodes, routeParam);
+                    resultsByRoute[routeKey] = map;
+                })
+            );
+
+            return keys.map((key) => {
+                const routeKey = key.routeId ?? 'all';
+                const predictionsMapForRoute = resultsByRoute[routeKey] ?? {};
+                const raw = predictionsMapForRoute[key.stopCode] ?? [];
+                const isOutbound = key.direction === 'OUTBOUND';
+                return createBusStopPredictionsFromActRealtime(raw, isOutbound);
+            });
+        },
+        {
+            cacheKeyFn: (key) => `${key.routeId}:${key.stopCode}:${key.direction}`,
+        }
     );
 }

--- a/src/mocks/context.ts
+++ b/src/mocks/context.ts
@@ -2,7 +2,7 @@ import { createMockEnv } from './env.js';
 
 import type { GraphQLContext } from '../context.js';
 import { createBusPositionsByRouteLoader } from '../loaders/busPosition.js';
-import { createBusStopByCodeLoader } from '../loaders/busStop.js';
+import { createBusStopByCodeLoader, createBusStopPredictionsLoader } from '../loaders/busStop.js';
 import { createACTRealtimeService } from '../services/actRealtime.js';
 import { createGTFSRealtimeService } from '../services/gtfsRealtime.js';
 import { getCachedOrFetch } from '../utils/cache.js';
@@ -56,6 +56,7 @@ export const createMockContext = (overrides?: Partial<GraphQLContext>): GraphQLC
     const defaultLoaders: GraphQLContext['loaders'] = {
         busStop: {
             byCode: createBusStopByCodeLoader(services.actRealtime),
+            predictions: createBusStopPredictionsLoader(services.actRealtime),
         },
         bus: {
             byRoute: createBusPositionsByRouteLoader(services.actRealtime),

--- a/src/schema/bus/bus.resolver.ts
+++ b/src/schema/bus/bus.resolver.ts
@@ -5,6 +5,8 @@ import type { GraphQLContext } from '../../context.js';
 import type { Resolvers } from '../../generated/graphql.js';
 import { type PositionParent, createPositionParent } from '../root/root.resolver.js';
 
+export type BusDirection = 'INBOUND' | 'OUTBOUND';
+
 export type BusParent = {
     __typename: 'Bus';
     vehicleId: string;

--- a/src/schema/bus/bus.schema.ts
+++ b/src/schema/bus/bus.schema.ts
@@ -1,5 +1,20 @@
 export const busDefs = /* GraphQL */ `
     """
+    Enum for bus direction
+    """
+    enum BusDirection {
+        """
+        Inbound (going towards downtown)
+        """
+        INBOUND
+
+        """
+        Outbound (going away from downtown)
+        """
+        OUTBOUND
+    }
+
+    """
     Represents a bus in any transit system
     """
     type Bus {

--- a/src/schema/busStop/busStop.schema.ts
+++ b/src/schema/busStop/busStop.schema.ts
@@ -66,4 +66,56 @@ export const busStopDefs = /* GraphQL */ `
             routeId: String!
         ): [AcTransitBusStop!]!
     }
+
+    """
+    Represents a predicted bus arrival at a stop
+    """
+    type BusStopPrediction {
+        """
+        Vehicle identifier for the approaching bus
+        """
+        vehicleId: String!
+
+        """
+        GTFS trip identifier
+        """
+        tripId: String!
+
+        """
+        Predicted arrival time
+        """
+        arrivalTime: DateTime!
+
+        """
+        Number of minutes until arrival
+        """
+        minutesAway: Int!
+
+        """
+        True if bus is heading outbound (away from downtown)
+        """
+        isOutbound: Boolean!
+    }
+
+    extend type Subscription {
+        """
+        Subscribe to real-time arrival predictions for a specific bus stop
+        """
+        busStopPredictions(
+            """
+            Route ID to filter by (e.g., "51B")
+            """
+            routeId: String!
+
+            """
+            Stop code to get predictions for (5-digit code from bus stop sign, e.g., "55555")
+            """
+            stopCode: String!
+
+            """
+            Direction to filter predictions (INBOUND towards Rockridge BART or OUTBOUND towards Berkeley Amtrak)
+            """
+            direction: BusDirection!
+        ): [BusStopPrediction!]!
+    }
 `;

--- a/src/services/__tests__/actRealtime.test.ts
+++ b/src/services/__tests__/actRealtime.test.ts
@@ -237,6 +237,33 @@ describe('ACT Realtime Service', () => {
             expect(mockFetch).toHaveBeenCalledTimes(1);
             expect(response).toEqual({});
         });
+
+        it('includes routeId in params when provided', async () => {
+            const stopIds = ['50373', '50374'];
+            const routeId = '51B';
+            const mockPredictions = stopIds.map((id) => createMockBusStopPredictionRaw({ stpid: id }));
+            const mockResponse = createMockBusStopPredictionsResponse({
+                'bustime-response': {
+                    prd: mockPredictions,
+                },
+            });
+            const mockFetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: vi.fn().mockResolvedValue(mockResponse),
+            });
+            const service = createACTRealtimeService({
+                ...defaultDependencies,
+                fetchWithUrlParams: mockFetch,
+            });
+
+            await service.fetchBusStopPredictions(stopIds, routeId);
+
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            const firstCallArg = mockFetch.mock.calls[0][0];
+            expect(firstCallArg).toMatchObject({
+                params: expect.objectContaining({ rt: routeId, stpid: stopIds.join(',') }),
+            });
+        });
     });
 
     describe('fetch system time', () => {


### PR DESCRIPTION
This pull request introduces a new DataLoader for fetching bus stop predictions, removes unused fields from the bus stop prediction data structures, and adds comprehensive tests for both bus position and bus stop loaders. It also introduces a new `BusDirection` enum to the GraphQL schema and updates the context and mocks to support the new loader. These changes improve data fetching efficiency, streamline the prediction data model, and enhance test coverage.

**Bus Stop Predictions Loader and Context Integration:**
- Added a new `createBusStopPredictionsLoader` DataLoader in `busStop.ts` for efficient, batched fetching of bus stop predictions from the ACTRealtime service. This loader groups requests by route and stop, and is integrated into the app context, mocks, and loader types. [[1]](diffhunk://#diff-d5830bc8af2993269387d0196ae0b68f7bcc8b279780c53643c0a78eb062aeb9R23-R64) [[2]](diffhunk://#diff-0cd594dddd6a9f2e3e26afebbb92716434437d7001c2416252aa7531e7f2b8d4L6-R11) [[3]](diffhunk://#diff-0cd594dddd6a9f2e3e26afebbb92716434437d7001c2416252aa7531e7f2b8d4R22) [[4]](diffhunk://#diff-0cd594dddd6a9f2e3e26afebbb92716434437d7001c2416252aa7531e7f2b8d4R39) [[5]](diffhunk://#diff-c580f636f8b6be76f538d622282e23ebfc53df49ade99e12288a324db36210c8L5-R5) [[6]](diffhunk://#diff-c580f636f8b6be76f538d622282e23ebfc53df49ade99e12288a324db36210c8R59)

**Bus Stop Prediction Data Model Simplification:**
- Removed the `departureTime` and `distanceToStopFeet` fields from the `BusStopPrediction` type and associated formatter functions, simplifying the prediction structure. [[1]](diffhunk://#diff-ea7ed625ead0cf3a79928efdeff7f1f939e003dbf57fe91763c2ee65fb714546L10-L13) [[2]](diffhunk://#diff-ea7ed625ead0cf3a79928efdeff7f1f939e003dbf57fe91763c2ee65fb714546L57-L60) [[3]](diffhunk://#diff-ea7ed625ead0cf3a79928efdeff7f1f939e003dbf57fe91763c2ee65fb714546L97) [[4]](diffhunk://#diff-ea7ed625ead0cf3a79928efdeff7f1f939e003dbf57fe91763c2ee65fb714546L107-L109)
- Updated all relevant tests to reflect the new, simplified shape of bus stop prediction data. [[1]](diffhunk://#diff-b1535ca0e8498a646c340f7b88d6a811c515c78b1f9e8ca30015b7bddfe6a51dL58-L69) [[2]](diffhunk://#diff-b1535ca0e8498a646c340f7b88d6a811c515c78b1f9e8ca30015b7bddfe6a51dL88) [[3]](diffhunk://#diff-b1535ca0e8498a646c340f7b88d6a811c515c78b1f9e8ca30015b7bddfe6a51dL179-L189)

**Testing Improvements:**
- Added new test suites for `busPosition` and `busStop` loaders, covering batching, error handling, and edge cases for both profiles and predictions. [[1]](diffhunk://#diff-b2bc1d514cfbc299e03fa3013fdd2abf910e98142ad4bf169ec7bad8b7fc2a7fR1-R58) [[2]](diffhunk://#diff-3e4093a135fd72b36d41eaa9207bbedb9b7c77a10ed0d8116256f3677f1ce62cR1-R74)

**GraphQL Schema and Type Updates:**
- Introduced a `BusDirection` enum (`INBOUND`/`OUTBOUND`) to the GraphQL schema and corresponding TypeScript types, standardizing direction handling across the codebase. [[1]](diffhunk://#diff-ea303162bc6e66e40417747c613bdde8df2e4bb62d5684e599f70292fe7e40c3R2-R16) [[2]](diffhunk://#diff-40344d3b7617e813e06bc1eda980de43f5f81d0f6abcec874c40b7d94b16d397R8-R9)

**Test and Mock Context Enhancements:**
- Updated the mock context and test client setup to support the new predictions loader and direction enum, ensuring all new functionality is testable in isolation. [[1]](diffhunk://#diff-ead7cd87c430c6d657c9f39c92ae4f2e9ca9d79def837fcaff4cd547a1d3f341L3-R11) [[2]](diffhunk://#diff-c580f636f8b6be76f538d622282e23ebfc53df49ade99e12288a324db36210c8L5-R5) [[3]](diffhunk://#diff-c580f636f8b6be76f538d622282e23ebfc53df49ade99e12288a324db36210c8R59)

These changes collectively improve the maintainability, efficiency, and testability of bus stop prediction data handling in the codebase.