### PR TITLE
add resolver act system time

### DIFF
--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -538,3 +538,16 @@ export type BusStopPredictionsSubscription = {
     __typename?: 'Subscription';
     busStopPredictions: Array<{ __typename?: 'BusStopPrediction'; vehicleId: string }>;
 };
+
+export type GetTransitSystemQueryQueryVariables = Exact<{
+    alias: Scalars['String']['input'];
+}>;
+
+export type GetTransitSystemQueryQuery = {
+    __typename?: 'Query';
+    getTransitSystem: { __typename?: 'ACTransitSystem'; alias: string; name: string } | null;
+};
+
+export type ActSystemTimeSubscriptionVariables = Exact<{ [key: string]: never }>;
+
+export type ActSystemTimeSubscription = { __typename?: 'Subscription'; acTransitSystemTime: Date };

--- a/src/schema/transitSystem/__tests__/transitSystem.resolver.test.ts
+++ b/src/schema/transitSystem/__tests__/transitSystem.resolver.test.ts
@@ -1,4 +1,9 @@
+import type { Services } from '../../../context.js';
+import type { GetTransitSystemQueryQuery } from '../../../generated/graphql.js';
 import { createTestClient, type TestGraphQLClient } from '../../../mocks/client.js';
+import { createMockEnv } from '../../../mocks/env.js';
+import { createMockACTRealtimeService } from '../../../services/__mocks__/actRealtime.js';
+import type { ACTRealtimeServiceType } from '../../../services/actRealtime.js';
 
 describe('transitSystemResolvers', () => {
     let client: TestGraphQLClient;
@@ -7,10 +12,94 @@ describe('transitSystemResolvers', () => {
         client = createTestClient();
     });
 
-    describe('TransitSystem.placeholder', () => {
-        it('resolves', async () => {
-            console.log('TODO: implement transitSystemResolvers tests', client);
-            return; // TODO
+    describe('Query.getTransitSystem', () => {
+        const query = /* GraphQL */ `
+            query GetTransitSystemQuery($alias: String!) {
+                getTransitSystem(alias: $alias) {
+                    ... on ACTransitSystem {
+                        alias
+                        name
+                    }
+                }
+            }
+        `;
+
+        it('returns ACTransitSystem for alias "act"', async () => {
+            const { data, errors } = await client.request<GetTransitSystemQueryQuery>(query, { alias: 'act' });
+
+            expect(errors).toBeUndefined();
+            expect(data).toEqual({
+                getTransitSystem: {
+                    alias: 'act',
+                    name: 'AC Transit',
+                },
+            });
+        });
+
+        it('returns null for unknown alias', async () => {
+            const { data, errors } = await client.request(query, { alias: 'invalid' });
+
+            expect(errors).toBeUndefined();
+            expect(data).toEqual({
+                getTransitSystem: null,
+            });
+        });
+    });
+
+    describe('Subscription.acTransitSystemTime', () => {
+        it('emits multiple events over time (initial + 2 loops)', async () => {
+            const query = /* GraphQL */ `
+                subscription ACTSystemTime {
+                    acTransitSystemTime
+                }
+            `;
+
+            const t1 = new Date('2024-07-01T12:00:00.000Z');
+            const t2 = new Date('2024-07-01T12:00:15.000Z');
+            const t3 = new Date('2024-07-01T12:00:30.000Z');
+
+            const fetchSystemTime = vi
+                .fn()
+                .mockResolvedValueOnce(t1)
+                .mockResolvedValueOnce(t2)
+                .mockResolvedValueOnce(t3);
+
+            const mockActRealtimeService = createMockACTRealtimeService({ fetchSystemTime });
+            const env = createMockEnv({ AC_TRANSIT_POLLING_INTERVAL: 5000 });
+            const mockContext = {
+                services: { actRealtime: mockActRealtimeService as ACTRealtimeServiceType } as Services,
+                env,
+            };
+
+            vi.useFakeTimers();
+
+            const eventsPromise = client.collectSubscription<{ acTransitSystemTime: string }>(
+                query,
+                undefined,
+                mockContext,
+                { take: 3 }
+            );
+
+            // Trigger two additional ticks
+            await vi.advanceTimersByTimeAsync(env.AC_TRANSIT_POLLING_INTERVAL);
+            await vi.advanceTimersByTimeAsync(env.AC_TRANSIT_POLLING_INTERVAL);
+
+            const events = await eventsPromise;
+
+            expect(Array.isArray(events)).toBe(true);
+            expect(events).toHaveLength(3);
+            events.forEach(({ errors }) => expect(errors).toBeUndefined());
+
+            expect(events[0].data?.acTransitSystemTime).toBe(t1.toISOString());
+            expect(events[1].data?.acTransitSystemTime).toBe(t2.toISOString());
+            expect(events[2].data?.acTransitSystemTime).toBe(t3.toISOString());
+
+            expect(fetchSystemTime).toHaveBeenCalledTimes(3);
+            expect(fetchSystemTime).toHaveBeenNthCalledWith(1);
+            expect(fetchSystemTime).toHaveBeenNthCalledWith(2);
+            expect(fetchSystemTime).toHaveBeenNthCalledWith(3);
+
+            vi.useRealTimers();
         });
     });
 });


### PR DESCRIPTION
This pull request adds comprehensive tests and a new subscription resolver for the AC Transit system in the GraphQL API. The tests now cover both querying and subscribing to AC Transit system data, and the resolver implements a real-time subscription that emits the system time at regular intervals.

**Testing improvements:**

- Added tests for the `Query.getTransitSystem` resolver, verifying correct responses for both valid and invalid aliases. [[1]](diffhunk://#diff-26673810aca0bce0aadba429b20d367e112831e33cf92d8e4d52f396708aaeebR1-R6) [[2]](diffhunk://#diff-26673810aca0bce0aadba429b20d367e112831e33cf92d8e4d52f396708aaeebL10-R102)
- Added tests for the `Subscription.acTransitSystemTime` resolver, ensuring it emits multiple events over time and returns the expected system times. [[1]](diffhunk://#diff-26673810aca0bce0aadba429b20d367e112831e33cf92d8e4d52f396708aaeebR1-R6) [[2]](diffhunk://#diff-26673810aca0bce0aadba429b20d367e112831e33cf92d8e4d52f396708aaeebL10-R102)

**Resolver enhancements:**

- Implemented the `Subscription.acTransitSystemTime` resolver, which emits the AC Transit system time at a configurable polling interval using async iteration.
- Added `__resolveType` to the `TransitSystem` resolver with coverage ignore comments for improved type resolution and test coverage reporting.